### PR TITLE
assigned JVM_EXTRA_OPTS to cassandraJvmOptions

### DIFF
--- a/src/main/scala/net/elodina/mesos/dse/CassandraProcess.scala
+++ b/src/main/scala/net/elodina/mesos/dse/CassandraProcess.scala
@@ -62,8 +62,10 @@ case class CassandraProcess(node: Node, taskInfo: TaskInfo, address: String, env
       .redirectOutput(new File(Executor.dir, "cassandra.out"))
       .redirectError(new File(Executor.dir, "cassandra.err"))
 
-    if (node.cassandraJvmOptions != null)
+    if (node.cassandraJvmOptions != null) {
       builder.environment().put("JVM_OPTS", node.cassandraJvmOptions)
+      builder.environment().put("JVM_EXTRA_OPTS", node.cassandraJvmOptions)
+    }
 
     builder.environment().putAll(env)
     builder.start()


### PR DESCRIPTION
Temporary quick fix to override cassandra-env.sh default
calculation of max-heap-size and new-heap-size in order to
avoid OOM due to different hardware setup (since stack file
has single configuration for node across all servers).

Simple example of this would be the following - we had a stack where
Cassandra node had 4500 MB ram allocated to it. This configuration
worked fine on 8 GB machine but OOM'ed on 32 GB machine.
