### PR TITLE
Better memory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ DataStax Enterprise Mesos Framework
 [Typical operations](#typical-operations)
 * [Shutting down framework](#shutting-down-framework)
 * [Rolling restart](#rolling-restart)
+* [Memory configuration](#memory-configuration)
 
 [Navigating the CLI](#navigating-the-cli)
 * [Requesting help](#requesting-help)
@@ -276,6 +277,28 @@ Some times node could timeout on start or stop, in such case restart halts with 
 ./dse-mesos.sh node restart 0..1 --timeout 8min
 Error: node 1 timeout on start
 ```
+
+Memory configuration
+--------------------
+
+Given by `--mem` option RAM will be consumed by executor, DSE process, DSE agent.
+DSE process capped by Xmx, however also consumes `offheap` memory. By default
+- Xmx = max(min(1/2 mem, 1024MB), min(1/4 mem, 8GB))
+- Xmn = min(100 * cpu, 1/4 * Xmx)
+
+To override default Xmx and/or Xmn calculation specify it via `--cassandra-jvm-options`, for instance:
+```
+./dse-mesos.sh node update 0 --cassandra-jvm-options "-Xmx1024M"
+```
+in this case `Xmn` will be calculated by default (according to given `Xmx` in `--cassandra-jvm-options`), or override only `Xmn`
+```
+./dse-mesos.sh node update 0 --cassandra-jvm-options "-Xmn100M"
+```
+or both
+```
+./dse-mesos.sh node update 0 --cassandra-jvm-options "-Xmx2048M -Xmn100M"
+```
+`Xmx`, `Xmn` correspond to env variables `MAX_HEAP_SIZE`, `HEAP_NEWSIZE` and will be set in `cassandra-env.sh`
 
 Navigating the CLI
 ==================

--- a/src/main/scala/net/elodina/mesos/dse/CassandraProcess.scala
+++ b/src/main/scala/net/elodina/mesos/dse/CassandraProcess.scala
@@ -62,10 +62,8 @@ case class CassandraProcess(node: Node, taskInfo: TaskInfo, address: String, env
       .redirectOutput(new File(Executor.dir, "cassandra.out"))
       .redirectError(new File(Executor.dir, "cassandra.err"))
 
-    if (node.cassandraJvmOptions != null) {
+    if (node.cassandraJvmOptions != null)
       builder.environment().put("JVM_OPTS", node.cassandraJvmOptions)
-      builder.environment().put("JVM_EXTRA_OPTS", node.cassandraJvmOptions)
-    }
 
     builder.environment().putAll(env)
     builder.start()

--- a/src/main/scala/net/elodina/mesos/dse/CassandraProcess.scala
+++ b/src/main/scala/net/elodina/mesos/dse/CassandraProcess.scala
@@ -147,12 +147,20 @@ case class CassandraProcess(node: Node, taskInfo: TaskInfo, address: String, env
       Util.IO.replaceInFile(new File(Executor.dseDir, "bin/dse.in.sh"), Map("CASSANDRA_LOG_DIR=.*" -> s"CASSANDRA_LOG_DIR=${Executor.dir}/data/log"))
   }
 
-  private def editCassandraConfigs() {
+  private[dse] def editCassandraConfigs() {
     val confDir = Executor.cassandraConfDir
 
     editCassandraYaml(new File(confDir , "cassandra.yaml"))
     Util.IO.replaceInFile(new File(confDir, "cassandra-rackdc.properties"), Map("dc=.*" -> s"dc=${node.dc}", "rack=.*" -> s"rack=${node.rack}"))
-    Util.IO.replaceInFile(new File(confDir, "cassandra-env.sh"), Map("JMX_PORT=.*" -> s"JMX_PORT=${node.runtime.reservation.ports(Node.Port.JMX)}"))
+    editCassandraEnvSh(new File(confDir, "cassandra-env.sh"))
+  }
+
+  private[dse] def editCassandraEnvSh(file: File) {
+    Util.IO.replaceInFile(file, Map(
+      "JMX_PORT=.*" -> s"JMX_PORT=${node.runtime.reservation.ports(Node.Port.JMX)}",
+      "#MAX_HEAP_SIZE=.*" -> s"MAX_HEAP_SIZE=${node.maxHeap}",
+      "#HEAP_NEWSIZE=.*" -> s"HEAP_NEWSIZE=${node.youngGenHeap}"
+    ))
   }
 
   private def editCassandraYaml(file: File) {

--- a/src/main/scala/net/elodina/mesos/dse/Node.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Node.scala
@@ -32,6 +32,8 @@ import net.elodina.mesos.dse.Node.Reservation
 import java.util.{TimeZone, Date}
 import Util.Period
 import java.text.SimpleDateFormat
+import Math._
+import Util.Size
 
 class Node extends Constrained {
   var id: String = null
@@ -315,6 +317,18 @@ class Node extends Constrained {
   }
 
   override def toString: String = id
+
+  def maxHeap: Size =
+    if (cassandraJvmOptions != null && cassandraJvmOptions.contains("-Xmx"))
+      new Size(cassandraJvmOptions.split(" ").find(_.startsWith("-Xmx")).get.substring(4))
+    else
+      new Size(max(min(0.5 * mem, 1024.0), min(0.25 * mem, 8 * 1024.0)).toLong + "M")
+
+  def youngGenHeap: Size =
+    if (cassandraJvmOptions != null && cassandraJvmOptions.contains("-Xmn"))
+      new Size(cassandraJvmOptions.split(" ").find(_.startsWith("-Xmn")).get.substring(4))
+    else
+      new Size(min(100.0 * cpu, 0.25 * maxHeap.toM.value).toLong + "M")
 }
 
 object Node {

--- a/src/main/test/net/elodina/mesos/dse/UtilTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/UtilTest.scala
@@ -365,4 +365,124 @@ class UtilTest {
     IO.replaceInFile(file, Map("a=*." -> "a=3", "c=*." -> "c=4"), ignoreMisses = true)
     assertEquals("a=3\nb=2", IO.readFile(file))
   }
+
+  @Test
+  def Size_init() {
+    new Size("0")
+    "kKmMgGtT".split("").foreach(unit => new Size("1" + unit))
+
+    // empty
+    try {
+      new Size("")
+      fail()
+    } catch { case e: IllegalArgumentException => }
+
+    // zero without units
+    new Size("0")
+
+    // no units, default: bytes
+    new Size("1")
+
+    // no value
+    try {
+      new Size("m")
+      fail()
+    } catch { case e: IllegalArgumentException => }
+
+    // wrong unit
+    try {
+      new Size("1v")
+      fail()
+    } catch { case e: IllegalArgumentException => }
+
+    // non-integer value
+    try {
+      new Size("0.5m")
+      fail()
+    } catch { case e: IllegalArgumentException => }
+
+    // invalid value
+    try {
+      new Size("Xh")
+      fail()
+    } catch { case e: IllegalArgumentException => }
+  }
+
+  @Test
+  def Size_common {
+    assertEquals(0, new Size("0").bytes)
+    assertEquals(1, new Size("1").bytes)
+
+    Seq("kK", "mM", "gG", "tT").zipWithIndex.foreach { case (group, index) =>
+      val bytesPerUnit = Math.pow(1024, index + 1).toLong
+      val value = scala.util.Random.nextInt(1024)
+      group.split("").filter(!_.isEmpty).foreach { unit =>
+        val s = "" + value + unit
+        val b = value * bytesPerUnit
+        assertEquals(s"$s should be $b bytes", b, new Size(s).bytes)
+        assertEquals(s"$s has value $value", value, new Size(s).value)
+        assertEquals(s"$s has value $unit", if (unit.isEmpty) null else unit, new Size(s).unit)
+        assertEquals(s"$s to string", s, "" + new Size(s))
+      }
+    }
+
+    assertEquals("1", "" + new Size("1"))
+  }
+
+  @Test
+  def Size_toUnit: Unit = {
+    assertEquals(new Size("1k"), new Size("1024").toUnit("K"))
+    assertEquals(new Size("1024k"), new Size("1048576").toUnit("K"))
+    assertEquals(new Size("1m"), new Size("1024K").toUnit("M"))
+    assertEquals(new Size("1g"), new Size("1024M").toUnit("G"))
+    assertEquals(new Size("1t"), new Size("1024G").toUnit("T"))
+
+    assertEquals(new Size("1024m"), new Size("1G").toUnit("M"))
+    assertEquals(new Size("1024k"), new Size("1M").toUnit("K"))
+    assertEquals(new Size("2048k"), new Size("2M").toUnit("K"))
+    assertEquals(new Size("2048"), new Size("2k").toUnit(""))
+
+    assertEquals(new Size("2048"), new Size("2k").toUnit(null))
+
+    val b2048 = new Size("2048")
+    assertSame(b2048, b2048.toB)
+    val m2048 = new Size("2048M")
+    assertSame(m2048, m2048.toM)
+    val m1024 = new Size("1024m")
+    assertSame(m1024, m1024.toM)
+
+    assertEquals("0M", "" + new Size("0").toM)
+    assertEquals("1M", "" + new Size("1572864").toM)
+    assertEquals("1M", "" + new Size("1024K").toM)
+    assertEquals("1M", "" + new Size("1054K").toM)
+    assertEquals("1024M", "" + new Size("1G").toM)
+    assertEquals("1048576M", "" + new Size("1T").toM)
+
+    assertEquals(new Size("3072m"), new Size("3G").toM)
+    assertEquals(new Size("1024k"), new Size("1M").toK)
+    assertEquals(new Size("2048k"), new Size("2M").toK)
+    assertEquals(new Size("2048"), new Size("2k").toB)
+  }
+
+  @Test
+  def Size_normalize: Unit = {
+    assertEquals("" + new Size("1K"), "" + new Size("1024").normalize)
+    assertEquals("" + new Size("1M"), "" + new Size("1048576").normalize)
+    assertEquals("" + new Size("1G"), "" + new Size("1073741824").normalize)
+    assertEquals("" + new Size("1T"), "" + new Size("1099511627776").normalize)
+
+    assertEquals("" + new Size("5K"), "" + new Size("5120").normalize)
+    assertEquals("" + new Size("3M"), "" + new Size("3145728").normalize)
+    assertEquals("" + new Size("7G"), "" + new Size("7516192768").normalize)
+    assertEquals("" + new Size("4T"), "" + new Size("4398046511104").normalize)
+
+    assertEquals("" + new Size("1M"), "" + new Size("1024K").normalize)
+    assertEquals("" + new Size("1G"), "" + new Size("1048576K").normalize)
+    assertEquals("" + new Size("1T"), "" + new Size("1073741824K").normalize)
+
+    assertEquals("" + new Size("1G"), "" + new Size("1024M").normalize)
+    assertEquals("" + new Size("1T"), "" + new Size("1048576M").normalize)
+
+    assertEquals("" + new Size("1T"), "" + new Size("1024G").normalize)
+  }
 }


### PR DESCRIPTION
MOTIVATION
Avoid OOM errors on servers when node `--mem` option is less than 1/2 total RAM on server.

PROPOSED CHANGE:
Extract Xmx ans Xmn from cassandra-jmv-options
- whenever Xmx is not set, calculate it using formula xmx = `max(min(1/2 * mem, 1024MB), min(1/4 * mem, 8GB))`
- whenever Xmn is not set, calcualte it using formula xmn = `min(100 MB * cpu, 1/4 * xmx)`
update `MAX_HEAP_SIZE`, `HEAP_NEWSIZE` in cassandra-env.sh

RESULT: flexible memory configuration
