### PR TITLE
Stop "handing" node in starting state when resource missing

### DIFF
--- a/src/main/scala/net/elodina/mesos/dse/Node.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Node.scala
@@ -37,7 +37,7 @@ import Util.Size
 
 class Node extends Constrained {
   var id: String = null
-  var state: Node.State.Value = Node.State.IDLE
+  @volatile var state: Node.State.Value = Node.State.IDLE
   var cluster: Cluster = Nodes.defaultCluster
   var stickiness: Node.Stickiness = new Node.Stickiness()
   var runtime: Node.Runtime = null

--- a/src/main/scala/net/elodina/mesos/dse/NodeCli.scala
+++ b/src/main/scala/net/elodina/mesos/dse/NodeCli.scala
@@ -246,6 +246,7 @@ object NodeCli {
       case "started" | "stopped" => title += s"$status:"
       case "scheduled" => title += s"$status to $cmd:"
       case "timeout" => throw new Error(s"$cmd timeout")
+      case "disconnected" => throw new Error("scheduler disconnected from the master")
     }
 
     printLine(title)
@@ -288,7 +289,7 @@ object NodeCli {
 
     val status = json("status")
 
-    if (status == "timeout") throw new Error(json("message").asInstanceOf[String])
+    if (status == "timeout" || status == "disconnected") throw new Error(json("message").asInstanceOf[String])
 
     val nodes = json("nodes").asInstanceOf[List[Any]]
       .map(n => new Node(n.asInstanceOf[Map[String, Any]], expanded = true))

--- a/src/main/scala/net/elodina/mesos/dse/Scheduler.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Scheduler.scala
@@ -247,10 +247,18 @@ object Scheduler extends org.apache.mesos.Scheduler with Constraints[Node] {
 
   def stopNode(id: String): Unit = {
     val node = Nodes.getNode(id)
-    if (node == null || node.runtime == null) return
+    if (node == null) return
+
+    if (node.runtime == null) {
+      node.state = Node.State.IDLE
+      return
+    }
+
+    if (driver == null) throw new IllegalStateException("scheduler disconnected from the master")
 
     logger.info(s"Killing task ${node.runtime.taskId} of node ${node.id}")
     driver.killTask(TaskID.newBuilder().setValue(node.runtime.taskId).build)
+
     node.state = Node.State.STOPPING
   }
 

--- a/src/main/test/net/elodina/mesos/dse/MesosTestCase.scala
+++ b/src/main/test/net/elodina/mesos/dse/MesosTestCase.scala
@@ -33,6 +33,7 @@ import org.apache.log4j.BasicConfigurator
 import com.google.protobuf.ByteString
 import java.io.{PrintStream, ByteArrayOutputStream, File}
 import java.nio.file.Files
+import scala.concurrent.duration.Duration
 
 @Ignore
 class MesosTestCase {
@@ -436,6 +437,28 @@ class MesosTestCase {
     false
   }
 
+  def assertDifference[T: Numeric](expr: => T, difference: T = 1, message: String = "has to change")(action: => Unit): Unit = {
+    import scala.math.Numeric.Implicits._
+    val before = expr
+    action
+    val after = expr
+    assertEquals(message, difference, after - before)
+  }
+
+  def assertNoDifference[T: Numeric](expr: => T, message: String = "don't change")(action: => Unit): Unit = {
+    import scala.math.Numeric.Implicits._
+    val before = expr
+    action
+    val after = expr
+    assertEquals(message, 0, after - before)
+  }
+
+  def delay(duration: String = "100ms")(f: => Unit) = new Thread {
+    override def run(): Unit = {
+      Thread.sleep(Duration(duration).toMillis)
+      f
+    }
+  }.start()
 }
 
 trait CliTestCase{


### PR DESCRIPTION
MOTIVATION:

Scenario:
1. start node 0;
2. node hangs in starting, cause no port is available;
3. user is unable to stop node;

PROPOSED CHANGE:
- change state to `idle` when node doesn't have runtime immediately
- handle case when scheduler disconnected from the master in order to send kill task from http server

RESULT: node could be stopped via `node stop`
