### PR TITLE
take into account C* process exit code while awaiting consistent state

### DIFF
--- a/src/main/scala/net/elodina/mesos/dse/CassandraProcess.scala
+++ b/src/main/scala/net/elodina/mesos/dse/CassandraProcess.scala
@@ -70,7 +70,8 @@ case class CassandraProcess(node: Node, taskInfo: TaskInfo, address: String, env
   }
 
   def awaitConsistentState(): Boolean = {
-    while (!stopped) {
+    def exited: Boolean = try { process.exitValue(); true } catch { case e: IllegalThreadStateException => false }
+    while (!stopped && !exited) {
       try {
         val probe = new NodeProbe("localhost", node.runtime.reservation.ports(Node.Port.JMX))
 


### PR DESCRIPTION
MOTIVATION
When due to misconfiguration C* process exits, executor continues to exist forever,
node hangs in `starting` state.

PROPOSED CHANGE
- take into account C* process exit status while awaiting consistent state

RESULT: scheduler will receive task failed

NOTE: second part of solution is to add failover
