### PR TITLE
Node failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ DataStax Enterprise Mesos Framework
 * [Shutting down framework](#shutting-down-framework)
 * [Rolling restart](#rolling-restart)
 * [Memory configuration](#memory-configuration)
+* [Failed node recovery](#failed-node-recovery)
 
 [Navigating the CLI](#navigating-the-cli)
 * [Requesting help](#requesting-help)
@@ -316,6 +317,21 @@ or both
 ./dse-mesos.sh node update 0 --cassandra-jvm-options "-Xmx2048M -Xmn100M"
 ```
 `Xmx`, `Xmn` correspond to env variables `MAX_HEAP_SIZE`, `HEAP_NEWSIZE` and will be set in `cassandra-env.sh`
+
+Failed node recovery
+--------------------
+When a node fails, DSE mesos scheduler assumes that the failure is recoverable. The scheduler will try
+to restart the node after waiting failover-delay (i.e. 30s, 2m). The initial waiting delay is equal to failover-delay setting.
+After each consecutive failure this delay is doubled until it reaches failover-max-delay value.
+
+If failover-max-tries is defined and the consecutive failure count exceeds it, the node will be deactivated.
+
+The following failover settings exists:
+```
+--failover-delay     - initial failover delay to wait after failure (option value is required)
+--failover-max-delay - max failover delay (option value is required)
+--failover-max-tries - max failover tries to deactivate broker (to reset to unbound pass --failover-max-tries "")
+```
 
 Navigating the CLI
 ==================

--- a/src/main/scala/net/elodina/mesos/dse/Executor.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Executor.scala
@@ -103,8 +103,7 @@ object Executor extends org.apache.mesos.Executor {
       agentProcess.start()
     }
 
-    cassandraProcess.awaitNormalState()
-    driver.sendStatusUpdate(TaskStatus.newBuilder().setTaskId(task.getTaskId).setData(ByteString.copyFromUtf8(address)).setState(TaskState.TASK_RUNNING).build)
+    if (cassandraProcess.awaitNormalState()) driver.sendStatusUpdate(TaskStatus.newBuilder().setTaskId(task.getTaskId).setData(ByteString.copyFromUtf8(address)).setState(TaskState.TASK_RUNNING).build)
 
     val error = cassandraProcess.await()
     if (error == null) driver.sendStatusUpdate(TaskStatus.newBuilder().setTaskId(task.getTaskId).setState(TaskState.TASK_FINISHED).build)

--- a/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
+++ b/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
@@ -322,6 +322,7 @@ object HttpServer {
       var disconnected = false
       try {
         for (node <- nodes) {
+          node.failover.resetFailures()
           if (start) node.state = Node.State.STARTING
           else Scheduler.stopNode(node.id, force)
         }
@@ -379,6 +380,8 @@ object HttpServer {
       for (node <- nodes) {
         // check node is running, because it's state could have changed
         if (node.state != Node.State.RUNNING) throw new HttpError(400, s"node ${node.id} should be running")
+
+        node.failover.resetFailures()
 
         // stop
         try {

--- a/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
+++ b/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
@@ -106,7 +106,7 @@ object HttpServer {
       response.setHeader("Content-Disposition", "attachment; filename=\"" + file.getName + "\"")
       Util.IO.copyAndClose(new FileInputStream(file), response.getOutputStream)
     }
-    
+
     def handleNodeApi(request: HttpServletRequest, response: HttpServletResponse) {
       response.setContentType("application/json; charset=utf-8")
       request.setAttribute("jsonResponse", true)
@@ -120,7 +120,7 @@ object HttpServer {
       else if (uri == "restart") handleRestartNode(request, response)
       else response.sendError(404, "unsupported method")
     }
-    
+
     def handleClusterApi(request: HttpServletRequest, response: HttpServletResponse) {
       response.setContentType("application/json; charset=utf-8")
       request.setAttribute("jsonResponse", true)
@@ -194,18 +194,18 @@ object HttpServer {
 
       var failoverDelay: Period = null
       if (request.getParameter("failoverDelay") != null)
-	try { failoverDelay = new Period(request.getParameter("failoverDelay")) }
-	catch { case e: IllegalArgumentException => throw new HttpError(400, "invalid failoverDelay") }
+        try { failoverDelay = new Period(request.getParameter("failoverDelay")) }
+        catch { case e: IllegalArgumentException => throw new HttpError(400, "invalid failoverDelay") }
 
       var failoverMaxDelay: Period = null
       if (request.getParameter("failoverMaxDelay") != null)
-	try { failoverMaxDelay = new Period(request.getParameter("failoverMaxDelay")) }
-	catch { case e: IllegalArgumentException => throw new HttpError(400, "invalid failoverMaxDelay") }
+        try { failoverMaxDelay = new Period(request.getParameter("failoverMaxDelay")) }
+        catch { case e: IllegalArgumentException => throw new HttpError(400, "invalid failoverMaxDelay") }
 
       val failoverMaxTries: String = request.getParameter("failoverMaxTries")
       if (failoverMaxTries != null && failoverMaxTries != "")
-	try { Integer.valueOf(failoverMaxTries) }
-	catch { case e: NumberFormatException => throw new HttpError(400, "invalid failoverMaxTries") }
+        try { Integer.valueOf(failoverMaxTries) }
+        catch { case e: NumberFormatException => throw new HttpError(400, "invalid failoverMaxTries") }
 
       // collect nodes and check existence & state
       val nodes = new ListBuffer[Node]()
@@ -256,9 +256,9 @@ object HttpServer {
 
         if (cassandraJvmOptions != null) node.cassandraJvmOptions = if (cassandraJvmOptions != "") cassandraJvmOptions else null
 
-	if (failoverDelay != null) node.failover.delay = failoverDelay
-	if (failoverMaxDelay != null) node.failover.maxDelay = failoverMaxDelay
-	if (failoverMaxTries != null) node.failover.maxTries = if (failoverMaxTries != "") Integer.valueOf(failoverMaxTries) else null
+        if (failoverDelay != null) node.failover.delay = failoverDelay
+        if (failoverMaxDelay != null) node.failover.maxDelay = failoverMaxDelay
+        if (failoverMaxTries != null) node.failover.maxTries = if (failoverMaxTries != "") Integer.valueOf(failoverMaxTries) else null
       }
 
       for (node <- nodes) {
@@ -421,7 +421,7 @@ object HttpServer {
       val clustersJson = Nodes.getClusters.map(_.toJson)
       response.getWriter.println("" + new JSONArray(clustersJson))
     }
-    
+
     private def handleAddUpdateCluster(add: Boolean, request: HttpServletRequest, response: HttpServletResponse) {
       val id: String = request.getParameter("cluster")
       if (id == null || id.isEmpty) throw new HttpError(400, "cluster required")

--- a/src/main/scala/net/elodina/mesos/dse/Scheduler.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Scheduler.scala
@@ -246,12 +246,12 @@ object Scheduler extends org.apache.mesos.Scheduler with Constraints[Node] {
       if (node.failover.maxTries != null) msg += "/" + node.failover.maxTries
 
       if (!node.failover.isMaxTriesExceeded) {
-	msg += ", waiting " + node.failover.currentDelay
-	msg += ", next start ~ " + Str.dateTime(node.failover.delayExpires)
+        msg += ", waiting " + node.failover.currentDelay
+        msg += ", next start ~ " + Str.dateTime(node.failover.delayExpires)
       } else {
-	node.state = Node.State.STOPPING
-	msg += ", failure limit exceeded"
-	msg += ", stopping node"
+        node.state = Node.State.STOPPING
+        msg += ", failure limit exceeded"
+        msg += ", stopping node"
       }
 
       logger.info(msg)

--- a/src/main/scala/net/elodina/mesos/dse/Scheduler.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Scheduler.scala
@@ -147,10 +147,10 @@ object Scheduler extends org.apache.mesos.Scheduler with Constraints[Node] {
     Nodes.save()
   }
 
-  private[dse] def acceptOffer(offer: Offer): String = {
+  private[dse] def acceptOffer(offer: Offer, now: Date = new Date()): String = {
     if (Reconciler.isReconciling) return "reconciling"
 
-    val nodes: List[Node] = Nodes.getNodes.filter(_.state == Node.State.STARTING)
+    val nodes: List[Node] = Nodes.getNodes.filter(_.state == Node.State.STARTING).filterNot(_.failover.isWaitingDelay(now))
     if (nodes.isEmpty) return "no nodes to start"
 
     val starting = nodes.find(_.runtime != null).getOrElse(null)
@@ -158,7 +158,7 @@ object Scheduler extends org.apache.mesos.Scheduler with Constraints[Node] {
 
     val reasons = new ListBuffer[String]()
     for (node <- nodes.sortBy(!_.seed)) {
-      var reason = node.matches(offer)
+      var reason = node.matches(offer, now)
       if (reason == null) reason = checkSeedConstraints(offer, node).getOrElse(null)
       if (reason == null) reason = checkConstraints(offer, node).getOrElse(null)
 
@@ -225,7 +225,7 @@ object Scheduler extends org.apache.mesos.Scheduler with Constraints[Node] {
     node.registerStart(node.runtime.hostname)
   }
 
-  private[dse] def onTaskStopped(node: Node, status: TaskStatus) {
+  private[dse] def onTaskStopped(node: Node, status: TaskStatus, now: Date = new Date()) {
     val sameTask = node != null && node.runtime != null && node.runtime.taskId == status.getTaskId.getValue
     val expectedState = node != null && node.state != Node.State.IDLE
 
@@ -238,11 +238,28 @@ object Scheduler extends org.apache.mesos.Scheduler with Constraints[Node] {
     if (node.state == Node.State.RECONCILING)
       logger.info(s"Finished reconciling of node ${node.id}, task ${node.runtime.taskId}")
 
-    val targetState = if (node.state == Node.State.STOPPING) Node.State.IDLE else Node.State.STARTING
-    node.state = targetState
+    val failed = node.state != Node.State.STOPPING && status.getState != TaskState.TASK_FINISHED && status.getState != TaskState.TASK_KILLED
+    node.registerStop(now, failed)
+
+    if (failed) {
+      var msg = s"Node ${node.id} failed ${node.failover.failures}"
+      if (node.failover.maxTries != null) msg += "/" + node.failover.maxTries
+
+      if (!node.failover.isMaxTriesExceeded) {
+	msg += ", waiting " + node.failover.currentDelay
+	msg += ", next start ~ " + Str.dateTime(node.failover.delayExpires)
+      } else {
+	node.state = Node.State.STOPPING
+	msg += ", failure limit exceeded"
+	msg += ", stopping node"
+      }
+
+      logger.info(msg)
+    }
+
+    node.state = if (node.state == Node.State.STOPPING) Node.State.IDLE else Node.State.STARTING
     node.runtime = null
     node.modified = false
-    node.registerStop()
   }
 
   def stopNode(id: String, force: Boolean = false): Unit = {

--- a/src/main/scala/net/elodina/mesos/dse/Scheduler.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Scheduler.scala
@@ -267,6 +267,7 @@ object Scheduler extends org.apache.mesos.Scheduler with Constraints[Node] {
     if (node == null) return
 
     if (node.runtime == null) {
+      node.failover.resetFailures()
       node.state = Node.State.IDLE
       return
     }

--- a/src/main/test/net/elodina/mesos/dse/HttpServerTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/HttpServerTest.scala
@@ -177,7 +177,7 @@ class HttpServerTest extends MesosTestCase {
       assertEquals(Node.State.STARTING, node2.state)
 
       // running (modified is false) then update
-      Scheduler.acceptOffer(offer(resources = "cpus:2.0;mem:20480;ports:0..65000", hostname = "slave2"))
+      Scheduler.acceptOffer(offer(resources = "cpus:2.0;mem:20480;ports:0..65000", hostname = "slave2"), node2.failover.delayExpires)
       Scheduler.onTaskStarted(node2, taskStatus(node2.runtime.taskId, TaskState.TASK_RUNNING))
       assertEquals(Node.State.RUNNING, node2.state)
 

--- a/src/main/test/net/elodina/mesos/dse/MesosTestCase.scala
+++ b/src/main/test/net/elodina/mesos/dse/MesosTestCase.scala
@@ -17,7 +17,7 @@
 
 package net.elodina.mesos.dse
 
-import net.elodina.mesos.dse.Node.{Runtime, Stickiness, Reservation}
+import net.elodina.mesos.dse.Node.{Failover, Runtime, Stickiness, Reservation}
 import org.apache.mesos.Protos.Resource.DiskInfo.Persistence
 import org.apache.mesos.Protos.Resource.{DiskInfo, ReservationInfo}
 import org.apache.mesos.Protos.Volume.Mode
@@ -380,6 +380,7 @@ class MesosTestCase {
     assertEquals(expected.state, actual.state)
     assertEquals(expected.cluster, actual.cluster)
     assertStickinessEquals(expected.stickiness, actual.stickiness)
+    assertFailoverEquals(expected.failover, actual.failover)
     assertRuntimeEquals(expected.runtime, actual.runtime)
 
     assertEquals(expected.cpu, actual.cpu, 0.001)
@@ -414,6 +415,17 @@ class MesosTestCase {
     assertEquals(expected.period, actual.period)
     assertEquals(expected.hostname, actual.hostname)
     assertEquals(expected.stopTime, actual.stopTime)
+  }
+
+  def assertFailoverEquals(expected: Failover, actual: Failover) {
+    if (checkNulls(expected, actual)) return
+
+    assertEquals(expected.delay, actual.delay)
+    assertEquals(expected.maxDelay, actual.maxDelay)
+    assertEquals(expected.maxTries, actual.maxTries)
+
+    assertEquals(expected.failures, actual.failures)
+    assertEquals(expected.failureTime, actual.failureTime)
   }
 
   def assertRuntimeEquals(expected: Runtime, actual: Runtime) {

--- a/src/main/test/net/elodina/mesos/dse/NodeTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/NodeTest.scala
@@ -4,11 +4,11 @@ import org.junit.Test
 import org.junit.Assert._
 import org.apache.mesos.Protos.{TaskInfo, CommandInfo, ExecutorInfo}
 import scala.concurrent.duration.Duration
-import net.elodina.mesos.dse.Node.{Reservation, Runtime, Stickiness, Port}
+import net.elodina.mesos.dse.Node._
 import scala.collection.mutable
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ListBuffer
-import net.elodina.mesos.dse.Util.Range
+import net.elodina.mesos.dse.Util.{Period, Range}
 import java.util.Date
 
 class NodeTest extends MesosTestCase {
@@ -192,20 +192,10 @@ class NodeTest extends MesosTestCase {
   def waitFor {
     val node = new Node("0")
 
-    def deferStateSwitch(state: Node.State.Value, delay: Long) {
-      new Thread() {
-        override def run() {
-          setName(classOf[Node].getSimpleName + "-scheduleState")
-          Thread.sleep(delay)
-          node.state = state
-        }
-      }.start()
-    }
-
-    deferStateSwitch(Node.State.RUNNING, 100)
+    delay("100ms") { node.state = Node.State.RUNNING }
     assertTrue(node.waitFor(Node.State.RUNNING, Duration("200ms")))
 
-    deferStateSwitch(Node.State.IDLE, 100)
+    delay("100ms") { node.state = Node.State.IDLE }
     assertTrue(node.waitFor(Node.State.IDLE, Duration("200ms")))
 
     // timeout
@@ -374,4 +364,98 @@ class NodeTest extends MesosTestCase {
     assertStickinessEquals(stickiness, read)
   }
 
+  // Failover
+  @Test
+  def Failover_currentDelay {
+    val failover = new Failover(new Period("1s"), new Period("5s"))
+
+    failover.failures = 0
+    assertEquals(new Period("0s"), failover.currentDelay)
+
+    failover.failures = 1
+    assertEquals(new Period("1s"), failover.currentDelay)
+
+    failover.failures = 2
+    assertEquals(new Period("2s"), failover.currentDelay)
+
+    failover.failures = 3
+    assertEquals(new Period("4s"), failover.currentDelay)
+
+    failover.failures = 4
+    assertEquals(new Period("5s"), failover.currentDelay)
+
+    failover.failures = 100
+    assertEquals(new Period("5s"), failover.currentDelay)
+  }
+
+  @Test
+  def Failover_delayExpires {
+    val failover = new Failover(new Period("1s"))
+    assertEquals(new Date(0), failover.delayExpires)
+
+    failover.registerFailure(new Date(0))
+    assertEquals(new Date(1000), failover.delayExpires)
+
+    failover.failureTime = new Date(1000)
+    assertEquals(new Date(2000), failover.delayExpires)
+  }
+
+  @Test
+  def Failover_isWaitingDelay {
+    val failover = new Failover(new Period("1s"))
+    assertFalse(failover.isWaitingDelay(new Date(0)))
+
+    failover.registerFailure(new Date(0))
+
+    assertTrue(failover.isWaitingDelay(new Date(0)))
+    assertTrue(failover.isWaitingDelay(new Date(500)))
+    assertTrue(failover.isWaitingDelay(new Date(999)))
+    assertFalse(failover.isWaitingDelay(new Date(1000)))
+  }
+
+  @Test
+  def Failover_isMaxTriesExceeded {
+    val failover = new Failover()
+
+    failover.failures = 100
+    assertFalse(failover.isMaxTriesExceeded)
+
+    failover.maxTries = 50
+    assertTrue(failover.isMaxTriesExceeded)
+  }
+
+  @Test
+  def Failover_registerFailure_resetFailures {
+    val failover = new Failover()
+    assertEquals(0, failover.failures)
+    assertNull(failover.failureTime)
+
+    failover.registerFailure(new Date(1))
+    assertEquals(1, failover.failures)
+    assertEquals(new Date(1), failover.failureTime)
+
+    failover.registerFailure(new Date(2))
+    assertEquals(2, failover.failures)
+    assertEquals(new Date(2), failover.failureTime)
+
+    failover.resetFailures()
+    assertEquals(0, failover.failures)
+    assertNull(failover.failureTime)
+
+    failover.registerFailure()
+    assertEquals(1, failover.failures)
+  }
+
+  @Test
+  def Failover_toJson_fromJson {
+    val failover = new Failover(new Period("1s"), new Period("5s"))
+    failover.maxTries = 10
+    failover.resetFailures()
+    failover.registerFailure(new Date(0))
+
+    val read: Failover = new Failover()
+    read.fromJson(Util.parseJson("" + failover.toJson).asInstanceOf[Map[String, Object]])
+
+    assertFailoverEquals(failover, read)
+  }
 }

--- a/src/main/test/net/elodina/mesos/dse/SchedulerTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/SchedulerTest.scala
@@ -163,7 +163,13 @@ class SchedulerTest extends MesosTestCase {
       assertNull("" + state, node.runtime)
     }
 
-    // failover
+  }
+
+  @Test
+  def onTaskStopped_failover {
+    val node = Nodes.addNode(new Node("0"))
+    node.runtime = new Node.Runtime(taskId = "task")
+
     // register failure when on task update received task status failed, lost, error
     // when node was in state starting, running
     for(nodeState <- Seq(Node.State.STARTING, Node.State.RUNNING, Node.State.RECONCILING)) {

--- a/src/main/test/net/elodina/mesos/dse/SchedulerTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/SchedulerTest.scala
@@ -86,8 +86,8 @@ class SchedulerTest extends MesosTestCase {
       node.state = Node.State.STARTING
 
       assertDifference(node.failover.failures) {
-	Scheduler.onTaskStatus(taskStatus(id = node.runtime.taskId, state = taskState))
-	assertEquals(Node.State.STARTING, node.state)
+        Scheduler.onTaskStatus(taskStatus(id = node.runtime.taskId, state = taskState))
+        assertEquals(Node.State.STARTING, node.state)
       }
     }
   }
@@ -173,20 +173,20 @@ class SchedulerTest extends MesosTestCase {
       assertEquals(failures, node.failover.failures)
 
       for(taskState <- Seq(TaskState.TASK_LOST, TaskState.TASK_FAILED, TaskState.TASK_ERROR)) {
-	ts += 1
-	// try to start
-	node.runtime = new Node.Runtime(node, offer())
-	node.state = nodeState
-	if (node.state == Node.State.RUNNING) node.runtime.address = "slave0"
+        ts += 1
+        // try to start
+        node.runtime = new Node.Runtime(node, offer())
+        node.state = nodeState
+        if (node.state == Node.State.RUNNING) node.runtime.address = "slave0"
 
-	Scheduler.onTaskStopped(node, taskStatus(id = node.runtime.taskId, state = taskState), new Date(ts))
-	// when ever failure occurs and max tries not exceeded node state changed to starting
-	assertEquals(Node.State.STARTING, node.state)
+        Scheduler.onTaskStopped(node, taskStatus(id = node.runtime.taskId, state = taskState), new Date(ts))
+        // when ever failure occurs and max tries not exceeded node state changed to starting
+        assertEquals(Node.State.STARTING, node.state)
 
-	failures += 1
+        failures += 1
 
-	assertEquals(failures, node.failover.failures)
-	assertEquals(new Date(ts), node.failover.failureTime)
+        assertEquals(failures, node.failover.failures)
+        assertEquals(new Date(ts), node.failover.failureTime)
       }
     }
 
@@ -206,21 +206,21 @@ class SchedulerTest extends MesosTestCase {
     // stop node when exceeded max tries
     for(nodeState <- Seq(Node.State.STARTING, Node.State.RUNNING, Node.State.RECONCILING)) {
       for(taskState <- Seq(TaskState.TASK_LOST, TaskState.TASK_FAILED, TaskState.TASK_ERROR)) {
-	node.failover.resetFailures()
-	node.failover.registerFailure(new Date(1))
-	node.failover.registerFailure(new Date(2))
-	node.failover.maxTries = 3
+        node.failover.resetFailures()
+        node.failover.registerFailure(new Date(1))
+        node.failover.registerFailure(new Date(2))
+        node.failover.maxTries = 3
 
-	node.runtime = new Node.Runtime(node, offer())
-	node.state = nodeState
+        node.runtime = new Node.Runtime(node, offer())
+        node.state = nodeState
 
-	Scheduler.onTaskStopped(node, taskStatus(id = node.runtime.taskId, state = taskState), new Date(5))
-	// when ever failure occurs and max tries exceeded node state changed to idle
-	assert(node.idle)
+        Scheduler.onTaskStopped(node, taskStatus(id = node.runtime.taskId, state = taskState), new Date(5))
+        // when ever failure occurs and max tries exceeded node state changed to idle
+        assert(node.idle)
 
-	assertTrue(node.failover.isMaxTriesExceeded)
-	assertEquals(3, node.failover.failures)
-	assertEquals(new Date(5), node.failover.failureTime)
+        assertTrue(node.failover.isMaxTriesExceeded)
+        assertEquals(3, node.failover.failures)
+        assertEquals(new Date(5), node.failover.failureTime)
       }
     }
   }

--- a/vagrant/cassandra_schema.cql
+++ b/vagrant/cassandra_schema.cql
@@ -44,5 +44,10 @@ CREATE TABLE IF NOT EXISTS dse_mesos_framework(
         node_address_dot_yaml map<text, text>,
         node_cassandra_jvm_options text,
         node_modified boolean,
+        node_failover_delay text,
+        node_failover_max_delay text,
+        node_failover_max_tries int,
+        node_failover_failures int,
+        node_failover_failure_time timestamp,
         PRIMARY KEY(namespace, framework_id, cluster_id, node_id)
 );


### PR DESCRIPTION
MOTIVATION:

C* node could fail due to misconfiguration, memory, etc reasons. In order to mitigate
such failures and be able to handle them in automated way lets introduce failover delay, 
max delay and max tries.

PROPOSED CHANGE:

When a node fails, DSE mesos scheduler assumes that the failure is recoverable. The scheduler will try
to restart the node after waiting failover-delay (i.e. 30s, 2m). The initial waiting delay is equal to failover-delay setting.
After each consecutive failure this delay is doubled until it reaches failover-max-delay value.

If failover-max-tries is defined and the consecutive failure count exceeds it, the node will be deactivated.

The following failover settings exists:
```
--failover-delay     - initial failover delay to wait after failure (option value is required)
--failover-max-delay - max failover delay (option value is required)
--failover-max-tries - max failover tries to deactivate broker (to reset to unbound pass --failover-max-tries "")
```

CLI changes:
  `node add` and `node update` will allow to configure `--failover-delay` , `--failover-max-delay` , `--failover-max-tries` 

Http server changes:
  `/api/node/add` and `/api/node/update` will allow to configure `failoverDelay`, `failoverMaxDelay`, `failoverMaxTries`

Scheduler changes:
  
  - when considering starting, stopping take into account failover is waiting delay 
  - reset failures 
    - when node has been successfully started (on status update when started) 
    - when node bas been stopped 
  - register failure 
    - when on task update received task status failed, lost, error 
    - stop node when exceeded max tries 

C* storage changes:

  add ability to store failover, introduce columns:

      node_failover_delay text,
      node_failover_max_delay text,
      node_failover_max_tries int,
      node_failover_failures int,
      node_failover_failure_time timestamp

RESULT: failover with increased delay and ability to stop node after max tries (fixes #28)
