### PR TITLE
Allow node in starting, running, stopping state to be restarted

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ DataStax Enterprise Mesos Framework
 * [Shutting down framework](#shutting-down-framework)
 * [Rolling restart](#rolling-restart)
 * [Memory configuration](#memory-configuration)
+* [Failed node recovery](#failed-node-recovery)
 
 [Navigating the CLI](#navigating-the-cli)
 * [Requesting help](#requesting-help)
@@ -316,6 +317,21 @@ or both
 ./dse-mesos.sh node update 0 --cassandra-jvm-options "-Xmx2048M -Xmn100M"
 ```
 `Xmx`, `Xmn` correspond to env variables `MAX_HEAP_SIZE`, `HEAP_NEWSIZE` and will be set in `cassandra-env.sh`
+
+Failed node recovery
+--------------------
+When a node fails, DSE mesos scheduler assumes that the failure is recoverable. The scheduler will try
+to restart the node after waiting failover-delay (i.e. 30s, 2m). The initial waiting delay is equal to failover-delay setting.
+After each consecutive failure this delay is doubled until it reaches failover-max-delay value.
+
+If failover-max-tries is defined and the consecutive failure count exceeds it, the node will be deactivated.
+
+The following failover settings exists:
+```
+--failover-delay     - initial failover delay to wait after failure (option value is required)
+--failover-max-delay - max failover delay (option value is required)
+--failover-max-tries - max failover tries to deactivate broker (to reset to unbound pass --failover-max-tries "")
+```
 
 Navigating the CLI
 ==================

--- a/src/main/scala/net/elodina/mesos/dse/Executor.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Executor.scala
@@ -103,8 +103,7 @@ object Executor extends org.apache.mesos.Executor {
       agentProcess.start()
     }
 
-    cassandraProcess.awaitNormalState()
-    driver.sendStatusUpdate(TaskStatus.newBuilder().setTaskId(task.getTaskId).setData(ByteString.copyFromUtf8(address)).setState(TaskState.TASK_RUNNING).build)
+    if (cassandraProcess.awaitNormalState()) driver.sendStatusUpdate(TaskStatus.newBuilder().setTaskId(task.getTaskId).setData(ByteString.copyFromUtf8(address)).setState(TaskState.TASK_RUNNING).build)
 
     val error = cassandraProcess.await()
     if (error == null) driver.sendStatusUpdate(TaskStatus.newBuilder().setTaskId(task.getTaskId).setState(TaskState.TASK_FINISHED).build)

--- a/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
+++ b/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
@@ -106,7 +106,7 @@ object HttpServer {
       response.setHeader("Content-Disposition", "attachment; filename=\"" + file.getName + "\"")
       Util.IO.copyAndClose(new FileInputStream(file), response.getOutputStream)
     }
-    
+
     def handleNodeApi(request: HttpServletRequest, response: HttpServletResponse) {
       response.setContentType("application/json; charset=utf-8")
       request.setAttribute("jsonResponse", true)
@@ -120,7 +120,7 @@ object HttpServer {
       else if (uri == "restart") handleRestartNode(request, response)
       else response.sendError(404, "unsupported method")
     }
-    
+
     def handleClusterApi(request: HttpServletRequest, response: HttpServletResponse) {
       response.setContentType("application/json; charset=utf-8")
       request.setAttribute("jsonResponse", true)
@@ -192,6 +192,21 @@ object HttpServer {
       val addressDotYaml = Util.parseMap(request.getParameter("addressDotYaml"))
       val cassandraJvmOptions = request.getParameter("cassandraJvmOptions")
 
+      var failoverDelay: Period = null
+      if (request.getParameter("failoverDelay") != null)
+        try { failoverDelay = new Period(request.getParameter("failoverDelay")) }
+        catch { case e: IllegalArgumentException => throw new HttpError(400, "invalid failoverDelay") }
+
+      var failoverMaxDelay: Period = null
+      if (request.getParameter("failoverMaxDelay") != null)
+        try { failoverMaxDelay = new Period(request.getParameter("failoverMaxDelay")) }
+        catch { case e: IllegalArgumentException => throw new HttpError(400, "invalid failoverMaxDelay") }
+
+      val failoverMaxTries: String = request.getParameter("failoverMaxTries")
+      if (failoverMaxTries != null && failoverMaxTries != "")
+        try { Integer.valueOf(failoverMaxTries) }
+        catch { case e: NumberFormatException => throw new HttpError(400, "invalid failoverMaxTries") }
+
       // collect nodes and check existence & state
       val nodes = new ListBuffer[Node]()
       for (id <- ids) {
@@ -240,6 +255,10 @@ object HttpServer {
         }
 
         if (cassandraJvmOptions != null) node.cassandraJvmOptions = if (cassandraJvmOptions != "") cassandraJvmOptions else null
+
+        if (failoverDelay != null) node.failover.delay = failoverDelay
+        if (failoverMaxDelay != null) node.failover.maxDelay = failoverMaxDelay
+        if (failoverMaxTries != null) node.failover.maxTries = if (failoverMaxTries != "") Integer.valueOf(failoverMaxTries) else null
       }
 
       for (node <- nodes) {
@@ -303,6 +322,7 @@ object HttpServer {
       var disconnected = false
       try {
         for (node <- nodes) {
+          node.failover.resetFailures()
           if (start) node.state = Node.State.STARTING
           else Scheduler.stopNode(node.id, force)
         }
@@ -361,6 +381,8 @@ object HttpServer {
         // check node is running, because it's state could have changed
         if (node.state != Node.State.RUNNING) throw new HttpError(400, s"node ${node.id} should be running")
 
+        node.failover.resetFailures()
+
         // stop
         try {
           Scheduler.stopNode(node.id)
@@ -402,7 +424,7 @@ object HttpServer {
       val clustersJson = Nodes.getClusters.map(_.toJson)
       response.getWriter.println("" + new JSONArray(clustersJson))
     }
-    
+
     private def handleAddUpdateCluster(add: Boolean, request: HttpServletRequest, response: HttpServletResponse) {
       val id: String = request.getParameter("cluster")
       if (id == null || id.isEmpty) throw new HttpError(400, "cluster required")

--- a/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
+++ b/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
@@ -365,12 +365,17 @@ object HttpServer {
         catch { case e: IllegalArgumentException => throw new HttpError(400, "invalid timeout") }
       }
 
+      def checkState(node: Node) = {
+        if (node.state == Node.State.IDLE) throw new HttpError(400, s"node ${node.id} is idle")
+        if (node.state == Node.State.RECONCILING) throw new HttpError(400, s"node ${node.id} is reconciling")
+      }
+
       // check&collect nodes
       val nodes = new ListBuffer[Node]
       for (id <- ids) {
         val node = Nodes.getNode(id)
         if (node == null) throw new HttpError(400, s"node $id not found")
-        if (node.state != Node.State.RUNNING) throw new HttpError(400, s"node $id should be running")
+        checkState(node)
         nodes += node
       }
 
@@ -378,9 +383,8 @@ object HttpServer {
         new JSONObject(Map("status" -> "timeout", "message" -> s"node ${node.id} timeout on $stage"))
 
       for (node <- nodes) {
-        // check node is running, because it's state could have changed
-        if (node.state != Node.State.RUNNING) throw new HttpError(400, s"node ${node.id} should be running")
-
+        // check node is running, starting, stopping, because it's state could have changed
+        checkState(node)
         node.failover.resetFailures()
 
         // stop

--- a/src/main/test/net/elodina/mesos/dse/HttpServerTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/HttpServerTest.scala
@@ -177,7 +177,7 @@ class HttpServerTest extends MesosTestCase {
       assertEquals(Node.State.STARTING, node2.state)
 
       // running (modified is false) then update
-      Scheduler.acceptOffer(offer(resources = "cpus:2.0;mem:20480;ports:0..65000", hostname = "slave2"))
+      Scheduler.acceptOffer(offer(resources = "cpus:2.0;mem:20480;ports:0..65000", hostname = "slave2"), node2.failover.delayExpires)
       Scheduler.onTaskStarted(node2, taskStatus(node2.runtime.taskId, TaskState.TASK_RUNNING))
       assertEquals(Node.State.RUNNING, node2.state)
 

--- a/src/main/test/net/elodina/mesos/dse/MesosTestCase.scala
+++ b/src/main/test/net/elodina/mesos/dse/MesosTestCase.scala
@@ -17,7 +17,7 @@
 
 package net.elodina.mesos.dse
 
-import net.elodina.mesos.dse.Node.{Runtime, Stickiness, Reservation}
+import net.elodina.mesos.dse.Node.{Failover, Runtime, Stickiness, Reservation}
 import org.apache.mesos.Protos.Resource.DiskInfo.Persistence
 import org.apache.mesos.Protos.Resource.{DiskInfo, ReservationInfo}
 import org.apache.mesos.Protos.Volume.Mode
@@ -380,6 +380,7 @@ class MesosTestCase {
     assertEquals(expected.state, actual.state)
     assertEquals(expected.cluster, actual.cluster)
     assertStickinessEquals(expected.stickiness, actual.stickiness)
+    assertFailoverEquals(expected.failover, actual.failover)
     assertRuntimeEquals(expected.runtime, actual.runtime)
 
     assertEquals(expected.cpu, actual.cpu, 0.001)
@@ -414,6 +415,17 @@ class MesosTestCase {
     assertEquals(expected.period, actual.period)
     assertEquals(expected.hostname, actual.hostname)
     assertEquals(expected.stopTime, actual.stopTime)
+  }
+
+  def assertFailoverEquals(expected: Failover, actual: Failover) {
+    if (checkNulls(expected, actual)) return
+
+    assertEquals(expected.delay, actual.delay)
+    assertEquals(expected.maxDelay, actual.maxDelay)
+    assertEquals(expected.maxTries, actual.maxTries)
+
+    assertEquals(expected.failures, actual.failures)
+    assertEquals(expected.failureTime, actual.failureTime)
   }
 
   def assertRuntimeEquals(expected: Runtime, actual: Runtime) {

--- a/src/main/test/net/elodina/mesos/dse/NodeCliTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/NodeCliTest.scala
@@ -1,5 +1,7 @@
 package net.elodina.mesos.dse
 
+import net.elodina.mesos.dse.Node.Failover
+import net.elodina.mesos.dse.Util.Period
 import org.junit.{Test, Before, After}
 import org.junit.Assert._
 import scala.concurrent.duration._
@@ -52,26 +54,28 @@ class NodeCliTest extends MesosTestCase with CliTestCase {
   }
 
   @Test
-  def handleAddUpdate {
-    val node = new Node("0")
-    Nodes.addNode(node)
-    Nodes.save()
-    val defaultAddNodeResponse = "node added:\n" + outputToString { NodeCli.printNode(node, 1) }
-    Nodes.removeNode(node)
-    Nodes.save()
+  def handleAddUpdate() = {
+    {
+      val node = new Node("0")
+      Nodes.addNode(node)
+      Nodes.save()
+      val defaultAddNodeResponse = "node added:\n" + outputToString { NodeCli.printNode(node, 1) }
+      Nodes.removeNode(node)
+      Nodes.save()
 
-    assertCliResponse(Array("add", "0"), defaultAddNodeResponse)
-    assertEquals(Nodes.getNodes.size, 1)
+      assertCliResponse(Array("add", "0"), defaultAddNodeResponse)
+      assertEquals(Nodes.getNodes.size, 1)
 
-    val cluster = new Cluster("test-cluster")
-    val args = Array("update", "0", "--cluster", cluster.id)
+      val cluster = new Cluster("test-cluster")
+      val args = Array("update", "0", "--cluster", cluster.id)
 
-    assertCliError(args, "cluster not found")
+      assertCliError(args, "cluster not found")
 
-    Nodes.addCluster(cluster)
-    Nodes.save()
-    cli(args)
-    assertEquals(cluster.id, Nodes.getNode("0").cluster.id)
+      Nodes.addCluster(cluster)
+      Nodes.save()
+      cli(args)
+      assertEquals(cluster.id, Nodes.getNode("0").cluster.id)
+    }
 
     val options = Array(
       "--cpu", "10",
@@ -90,22 +94,36 @@ class NodeCliTest extends MesosTestCase with CliTestCase {
     )
     cli(Array("update", "0") ++ options)
 
-    {
-      val node = Nodes.getNode("0")
-      assertEquals(10.0, node.cpu, 0.001)
-      assertEquals(10, node.mem)
-      assertEquals("60m", node.stickiness.period.toString)
-      assertEquals("rack", node.rack)
-      assertEquals("dc", node.dc)
-      assertEquals(true, node.seed)
-      assertEquals("-Dfile.encoding=UTF8", node.jvmOptions)
-      assertEquals("/tmp/datadir", node.dataFileDirs)
-      assertEquals("/tmp/commitlog", node.commitLogDir)
-      assertEquals("/tmp/caches", node.savedCachesDir)
-      assertEquals(Map("num_tokens" -> "312", "hinted_handoff" -> "false"), node.cassandraDotYaml.toMap)
-      assertEquals(Map("stomp_interface" -> "11.22.33.44"), node.addressDotYaml.toMap)
-      assertEquals("-Dcassandra.replace_address=127.0.0.1 -Dcassandra.ring_delay_ms=15000", node.cassandraJvmOptions)
-    }
+    val node = Nodes.getNode("0")
+    assertEquals(10.0, node.cpu, 0.001)
+    assertEquals(10, node.mem)
+    assertEquals("60m", node.stickiness.period.toString)
+    assertEquals("rack", node.rack)
+    assertEquals("dc", node.dc)
+    assertEquals(true, node.seed)
+    assertEquals("-Dfile.encoding=UTF8", node.jvmOptions)
+    assertEquals("/tmp/datadir", node.dataFileDirs)
+    assertEquals("/tmp/commitlog", node.commitLogDir)
+    assertEquals("/tmp/caches", node.savedCachesDir)
+    assertEquals(Map("num_tokens" -> "312", "hinted_handoff" -> "false"), node.cassandraDotYaml.toMap)
+    assertEquals(Map("stomp_interface" -> "11.22.33.44"), node.addressDotYaml.toMap)
+    assertEquals("-Dcassandra.replace_address=127.0.0.1 -Dcassandra.ring_delay_ms=15000", node.cassandraJvmOptions)
+  }
+
+  @Test
+  def handleAddUpdate_failover: Unit = {
+    val outputAdd = outputToString { cli("add 0 --cpu 1.0 --mem 1024 --failover-delay 2m --failover-max-delay 25m --failover-max-tries 9".split(" ")) }
+
+    val node = Nodes.getNode("0")
+    assertFailoverEquals(new Failover(new Period("2m"), new Period("25m"), 9), node.failover)
+    assertTrue(outputAdd.contains("delay:2m, max-delay:25m, max-tries:9"))
+
+    cli("update 0 --failover-delay 5m --failover-max-delay 45m --failover-max-tries 7".split(" "))
+    assertFailoverEquals(new Failover(new Period("5m"), new Period("45m"), 7), node.failover)
+
+    // reset failover max tries
+    cli("update 0 --failover-max-tries".split(" ") ++ Array(""))
+    assertNull(node.failover.maxTries)
   }
 
   @Test
@@ -257,6 +275,8 @@ class NodeCliTest extends MesosTestCase with CliTestCase {
     assertCliErrorContains("restart 0..1 --timeout 1s".split(" "), "node 1 should be running")
 
     // 1 stop timeout
+    node1.failover.resetFailures()
+
     started(node1)
     node1.waitFor(RUNNING, Duration("200ms"))
 

--- a/src/main/test/net/elodina/mesos/dse/NodeTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/NodeTest.scala
@@ -4,11 +4,11 @@ import org.junit.Test
 import org.junit.Assert._
 import org.apache.mesos.Protos.{TaskInfo, CommandInfo, ExecutorInfo}
 import scala.concurrent.duration.Duration
-import net.elodina.mesos.dse.Node.{Reservation, Runtime, Stickiness, Port}
+import net.elodina.mesos.dse.Node._
 import scala.collection.mutable
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ListBuffer
-import net.elodina.mesos.dse.Util.Range
+import net.elodina.mesos.dse.Util.{Period, Range}
 import java.util.Date
 
 class NodeTest extends MesosTestCase {
@@ -192,20 +192,10 @@ class NodeTest extends MesosTestCase {
   def waitFor {
     val node = new Node("0")
 
-    def deferStateSwitch(state: Node.State.Value, delay: Long) {
-      new Thread() {
-        override def run() {
-          setName(classOf[Node].getSimpleName + "-scheduleState")
-          Thread.sleep(delay)
-          node.state = state
-        }
-      }.start()
-    }
-
-    deferStateSwitch(Node.State.RUNNING, 100)
+    delay("100ms") { node.state = Node.State.RUNNING }
     assertTrue(node.waitFor(Node.State.RUNNING, Duration("200ms")))
 
-    deferStateSwitch(Node.State.IDLE, 100)
+    delay("100ms") { node.state = Node.State.IDLE }
     assertTrue(node.waitFor(Node.State.IDLE, Duration("200ms")))
 
     // timeout
@@ -374,4 +364,98 @@ class NodeTest extends MesosTestCase {
     assertStickinessEquals(stickiness, read)
   }
 
+  // Failover
+  @Test
+  def Failover_currentDelay {
+    val failover = new Failover(new Period("1s"), new Period("5s"))
+
+    failover.failures = 0
+    assertEquals(new Period("0s"), failover.currentDelay)
+
+    failover.failures = 1
+    assertEquals(new Period("1s"), failover.currentDelay)
+
+    failover.failures = 2
+    assertEquals(new Period("2s"), failover.currentDelay)
+
+    failover.failures = 3
+    assertEquals(new Period("4s"), failover.currentDelay)
+
+    failover.failures = 4
+    assertEquals(new Period("5s"), failover.currentDelay)
+
+    failover.failures = 100
+    assertEquals(new Period("5s"), failover.currentDelay)
+  }
+
+  @Test
+  def Failover_delayExpires {
+    val failover = new Failover(new Period("1s"))
+    assertEquals(new Date(0), failover.delayExpires)
+
+    failover.registerFailure(new Date(0))
+    assertEquals(new Date(1000), failover.delayExpires)
+
+    failover.failureTime = new Date(1000)
+    assertEquals(new Date(2000), failover.delayExpires)
+  }
+
+  @Test
+  def Failover_isWaitingDelay {
+    val failover = new Failover(new Period("1s"))
+    assertFalse(failover.isWaitingDelay(new Date(0)))
+
+    failover.registerFailure(new Date(0))
+
+    assertTrue(failover.isWaitingDelay(new Date(0)))
+    assertTrue(failover.isWaitingDelay(new Date(500)))
+    assertTrue(failover.isWaitingDelay(new Date(999)))
+    assertFalse(failover.isWaitingDelay(new Date(1000)))
+  }
+
+  @Test
+  def Failover_isMaxTriesExceeded {
+    val failover = new Failover()
+
+    failover.failures = 100
+    assertFalse(failover.isMaxTriesExceeded)
+
+    failover.maxTries = 50
+    assertTrue(failover.isMaxTriesExceeded)
+  }
+
+  @Test
+  def Failover_registerFailure_resetFailures {
+    val failover = new Failover()
+    assertEquals(0, failover.failures)
+    assertNull(failover.failureTime)
+
+    failover.registerFailure(new Date(1))
+    assertEquals(1, failover.failures)
+    assertEquals(new Date(1), failover.failureTime)
+
+    failover.registerFailure(new Date(2))
+    assertEquals(2, failover.failures)
+    assertEquals(new Date(2), failover.failureTime)
+
+    failover.resetFailures()
+    assertEquals(0, failover.failures)
+    assertNull(failover.failureTime)
+
+    failover.registerFailure()
+    assertEquals(1, failover.failures)
+  }
+
+  @Test
+  def Failover_toJson_fromJson {
+    val failover = new Failover(new Period("1s"), new Period("5s"))
+    failover.maxTries = 10
+    failover.resetFailures()
+    failover.registerFailure(new Date(0))
+
+    val read: Failover = new Failover()
+    read.fromJson(Util.parseJson("" + failover.toJson).asInstanceOf[Map[String, Object]])
+
+    assertFailoverEquals(failover, read)
+  }
 }

--- a/src/main/test/net/elodina/mesos/dse/SchedulerTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/SchedulerTest.scala
@@ -31,6 +31,13 @@ class SchedulerTest extends MesosTestCase {
     assertEquals(1, schedulerDriver.launchedTasks.size())
     assertEquals(Node.State.STARTING, node.state)
     assertNotNull(node.runtime)
+
+    // failover delay
+    Scheduler.statusUpdate(schedulerDriver, taskStatus(id = node.runtime.taskId, state = TaskState.TASK_FAILED))
+    assertEquals(1, node.failover.failures)
+    assertEquals("no nodes to start", Scheduler.acceptOffer(offer(resources = "cpus:1.0;mem:1024;ports:0..10")))
+
+    assertEquals(null, Scheduler.acceptOffer(offer(resources = "cpus:1.0;mem:1024;ports:0..10"), node.failover.delayExpires))
   }
 
   @Test
@@ -56,11 +63,13 @@ class SchedulerTest extends MesosTestCase {
     Scheduler.onTaskStatus(taskStatus(id = node.runtime.taskId, state = TaskState.TASK_RUNNING))
     assertEquals(Node.State.RUNNING, node.state)
     assertEquals(0, schedulerDriver.killedTasks.size())
+    assertEquals(0, node.failover.failures)
 
     // node failed
     Scheduler.onTaskStatus(taskStatus(id = node.runtime.taskId, state = TaskState.TASK_LOST))
     assertEquals(Node.State.STARTING, node.state)
     assertNull(node.runtime)
+    assertEquals(1, node.failover.failures)
 
     // node stopped
     node.runtime = new Node.Runtime(node, offer())
@@ -68,6 +77,19 @@ class SchedulerTest extends MesosTestCase {
     Scheduler.onTaskStatus(taskStatus(id = node.runtime.taskId, state = TaskState.TASK_FINISHED))
     assertEquals(Node.State.IDLE, node.state)
     assertNull(node.runtime)
+
+    // task state lost, failed, error considered as fail
+    node.failover.resetFailures()
+    for(taskState <- Seq(TaskState.TASK_LOST, TaskState.TASK_FAILED, TaskState.TASK_ERROR)) {
+      // try to start
+      node.runtime = new Node.Runtime(node, offer())
+      node.state = Node.State.STARTING
+
+      assertDifference(node.failover.failures) {
+        Scheduler.onTaskStatus(taskStatus(id = node.runtime.taskId, state = taskState))
+        assertEquals(Node.State.STARTING, node.state)
+      }
+    }
   }
 
   @Test
@@ -98,12 +120,18 @@ class SchedulerTest extends MesosTestCase {
       node.runtime = new Node.Runtime(taskId = "task")
       node.state = state
 
+      node.failover.resetFailures()
+      node.failover.registerFailure(new Date(1))
+
       Scheduler.onTaskStarted(node, taskStatus(id = "task", state = TaskState.TASK_RUNNING, data = "address"))
       assertEquals("" + state, 0, schedulerDriver.killedTasks.size())
       assertEquals("" + state, Node.State.RUNNING, node.state)
 
       if (state != Node.State.RECONCILING)
         assertEquals("" + state, "address", node.runtime.address)
+
+      assertEquals(0, node.failover.failures)
+      assertNull(node.failover.failureTime)
     }
   }
 
@@ -133,6 +161,73 @@ class SchedulerTest extends MesosTestCase {
       Scheduler.onTaskStopped(node, taskStatus(id = "task", state = TaskState.TASK_FAILED))
       assertEquals("" + state, Node.State.STARTING, node.state)
       assertNull("" + state, node.runtime)
+    }
+
+  }
+
+  @Test
+  def onTaskStopped_failover {
+    val node = Nodes.addNode(new Node("0"))
+    node.runtime = new Node.Runtime(taskId = "task")
+
+    // register failure when on task update received task status failed, lost, error
+    // when node was in state starting, running
+    for(nodeState <- Seq(Node.State.STARTING, Node.State.RUNNING, Node.State.RECONCILING)) {
+      var ts = 0L
+      var failures = 0
+      node.failover.resetFailures()
+      assertEquals(failures, node.failover.failures)
+
+      for(taskState <- Seq(TaskState.TASK_LOST, TaskState.TASK_FAILED, TaskState.TASK_ERROR)) {
+        ts += 1
+        // try to start
+        node.runtime = new Node.Runtime(node, offer())
+        node.state = nodeState
+        if (node.state == Node.State.RUNNING) node.runtime.address = "slave0"
+
+        Scheduler.onTaskStopped(node, taskStatus(id = node.runtime.taskId, state = taskState), new Date(ts))
+        // when ever failure occurs and max tries not exceeded node state changed to starting
+        assertEquals(Node.State.STARTING, node.state)
+
+        failures += 1
+
+        assertEquals(failures, node.failover.failures)
+        assertEquals(new Date(ts), node.failover.failureTime)
+      }
+    }
+
+    // when node was in status stopping
+    // reset failures when node bas been stopped (task finished or killed)
+    for(taskState <- Seq(TaskState.TASK_LOST, TaskState.TASK_FAILED, TaskState.TASK_ERROR, TaskState.TASK_FINISHED, TaskState.TASK_KILLED)) {
+      node.runtime = new Node.Runtime(node, offer())
+      node.state = Node.State.STOPPING
+
+      Scheduler.onTaskStopped(node, taskStatus(id = node.runtime.taskId, state = taskState))
+      assert(node.idle)
+
+      assertEquals(0, node.failover.failures)
+      assertNull(node.failover.failureTime)
+    }
+
+    // stop node when exceeded max tries
+    for(nodeState <- Seq(Node.State.STARTING, Node.State.RUNNING, Node.State.RECONCILING)) {
+      for(taskState <- Seq(TaskState.TASK_LOST, TaskState.TASK_FAILED, TaskState.TASK_ERROR)) {
+        node.failover.resetFailures()
+        node.failover.registerFailure(new Date(1))
+        node.failover.registerFailure(new Date(2))
+        node.failover.maxTries = 3
+
+        node.runtime = new Node.Runtime(node, offer())
+        node.state = nodeState
+
+        Scheduler.onTaskStopped(node, taskStatus(id = node.runtime.taskId, state = taskState), new Date(5))
+        // when ever failure occurs and max tries exceeded node state changed to idle
+        assert(node.idle)
+
+        assertTrue(node.failover.isMaxTriesExceeded)
+        assertEquals(3, node.failover.failures)
+        assertEquals(new Date(5), node.failover.failureTime)
+      }
     }
   }
 

--- a/vagrant/cassandra_schema.cql
+++ b/vagrant/cassandra_schema.cql
@@ -44,5 +44,10 @@ CREATE TABLE IF NOT EXISTS dse_mesos_framework(
         node_address_dot_yaml map<text, text>,
         node_cassandra_jvm_options text,
         node_modified boolean,
+        node_failover_delay text,
+        node_failover_max_delay text,
+        node_failover_max_tries int,
+        node_failover_failures int,
+        node_failover_failure_time timestamp,
         PRIMARY KEY(namespace, framework_id, cluster_id, node_id)
 );


### PR DESCRIPTION
MOTIVATION

There are times when its easier to relax state check from node should be running to 
node has to be in one of starting, running, stopping, however make sure you know what
you are doing, because otherwise it could cause node downtime. Thus being able to 
restart node useful in such cases (suggested by @dmitrypekar):
- starting node, recalling that have to change some option, change it then call `restart`
- starting node, however something was misconfigured, figuring out what and then change to correct one

PROPOSED CHANGE
- relax restart node state check to node being in any of starting, running, stopping

Http server: 
- allow node in starting, running, stopping state to be restarted

RESULT: ability to restart node in starting, running, stopping state
