### PR TITLE
Make --storage option required for scheduler cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Option (* = required)  Description
                          framework.
 --secret               Secret (password) used to register
                          framework.
---storage              Storage for cluster state. Examples:
+* --storage            Storage for cluster state. Examples:
                          file:dse-mesos.json; zk:master:
                          2181/dse-mesos.
 --user                 Mesos user. Defaults to current system

--- a/src/main/scala/net/elodina/mesos/dse/SchedulerCli.scala
+++ b/src/main/scala/net/elodina/mesos/dse/SchedulerCli.scala
@@ -3,7 +3,7 @@ package net.elodina.mesos.dse
 import joptsimple.{OptionException, OptionSet, OptionParser}
 import scala.concurrent.duration.Duration
 import java.io.File
-import Cli.{out, printLine, handleGenericOptions}
+import Cli.{out, printLine, handleGenericOptions, Error}
 
 object SchedulerCli {
   def isEnabled: Boolean = System.getenv("DM_NO_SCHEDULER") == null
@@ -20,7 +20,7 @@ object SchedulerCli {
     parser.accepts("framework-role", "Framework role. Defaults to *.").withRequiredArg().ofType(classOf[String])
     parser.accepts("framework-timeout", "Framework failover timeout. Defaults to 30 days.").withRequiredArg().ofType(classOf[String])
 
-    parser.accepts("storage", "Storage for nodes state. Examples: file:dse-mesos.json; zk:master:2181/dse-mesos; cassandra:9042:master.").withRequiredArg().ofType(classOf[String])
+    parser.accepts("storage", "Storage for nodes state. Examples: file:dse-mesos.json; zk:master:2181/dse-mesos; cassandra:9042:master.").withRequiredArg().required().ofType(classOf[String])
     parser.accepts("cassandra-keyspace", "Cassandra keyspace used to find framework state table. Required if storage=cassandra.").withRequiredArg().ofType(classOf[String])
     parser.accepts("cassandra-table", "Cassandra table where framework state to be persisted. Required if storage=cassandra").withRequiredArg().ofType(classOf[String])
     parser.accepts("debug", "Run in debug mode.").withRequiredArg().ofType(classOf[Boolean]).defaultsTo(false)
@@ -61,6 +61,7 @@ object SchedulerCli {
     if (options.has("framework-timeout")) Config.frameworkTimeout = Duration(options.valueOf("framework-timeout").asInstanceOf[String])
 
     if (options.has("storage")) Config.storage = options.valueOf("storage").asInstanceOf[String]
+
     if (Config.storage.startsWith("cassandra")){
       if (!options.has("cassandra-keyspace"))
         throw new Error("cassandra-keyspace is required if storage=cassandra")


### PR DESCRIPTION
MOTIVATION:
Currently, if the --storage flag is missing it will default to file, which shouldn't be ever used in production environments. To avoid situations when due to default value scheduler writes its state to file and after failover `node list` are empty, it would be great to make the storage flag required, so the case where you forget so set a highly available state storage is impossible and setting file storage for development purposes would be explicit.

PROPOSED CHANGES:
scheduler CLI make option `--storage` required, when it is not set user will see: 

    Option (* = required)  Description                           
    ---------------------  -----------                           
    ...

    * --storage            Storage for nodes state. Examples:    
                             file:dse-mesos.json; zk:master:     
                             2181/dse-mesos; cassandra:9042:     
                             master.                             
    ...
       

    Error: Missing required option(s) [storage]



RESULT: better user experience 