### PR TITLE
Progress for restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ Nodes will be restarted one by one, scheduler stops node then starts it, same ap
 
 ```
 # ./dse-mesos.sh node restart 0..1 --timeout 8min
+stopping node 0 ... done
+starting node 0 ... done
+stopping node 1 ... done
+starting node 1 ... done
 nodes restarted:
   id: 0
   state: running
@@ -293,7 +297,10 @@ Some times node could timeout on start or stop, in such case restart halts with 
 
 ```
 ./dse-mesos.sh node restart 0..1 --timeout 8min
-Error: node 1 timeout on start
+stopping node 0 ... done
+starting node 0 ... done
+stopping node 1 ... done
+starting node 1 ... Error: node 1 timeout on start
 ```
 
 Memory configuration

--- a/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
+++ b/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
@@ -354,7 +354,6 @@ object HttpServer {
     def handleRestartNode(request: HttpServletRequest, response: HttpServletResponse) {
       val withProgress: Boolean = request.getParameter("progress") != null
       if (withProgress) response.setHeader("Transfer-Encoding", "chunked")
-      request.getParameter("progress")
 
       def progress(msg: String) = {
         if (withProgress) {

--- a/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
+++ b/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
@@ -397,6 +397,7 @@ object HttpServer {
         try {
           checkState(node)
         } catch {
+          // with progress enabled headers are send when processing first node, thus can't send bad request
           case e: HttpError if withProgress && node != nodes(0) =>
             response.getWriter.println("" + new JSONObject(Map("status" -> "error", "message" -> e.getMessage)))
             return

--- a/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
+++ b/src/main/scala/net/elodina/mesos/dse/HttpServer.scala
@@ -352,6 +352,17 @@ object HttpServer {
     }
 
     def handleRestartNode(request: HttpServletRequest, response: HttpServletResponse) {
+      val withProgress: Boolean = request.getParameter("progress") != null
+      if (withProgress) response.setHeader("Transfer-Encoding", "chunked")
+      request.getParameter("progress")
+
+      def progress(msg: String) = {
+        if (withProgress) {
+          response.getWriter().write(msg + "\n")
+          response.flushBuffer()
+        }
+      }
+
       val expr: String = request.getParameter("node")
       if (expr == null || expr.isEmpty) throw new HttpError(400, "node required")
 
@@ -384,8 +395,17 @@ object HttpServer {
 
       for (node <- nodes) {
         // check node is running, starting, stopping, because it's state could have changed
-        checkState(node)
+        try {
+          checkState(node)
+        } catch {
+          case e: HttpError if withProgress && node != nodes(0) =>
+            response.getWriter.println("" + new JSONObject(Map("status" -> "error", "message" -> e.getMessage)))
+            return
+        }
+
         node.failover.resetFailures()
+
+        progress(s"stopping node ${node.id} ... ")
 
         // stop
         try {
@@ -405,6 +425,9 @@ object HttpServer {
           return
         }
 
+        progress("done")
+        progress(s"starting node ${node.id} ... ")
+
         val startTimeout = Duration(Math.max(timeout.toMillis - (System.currentTimeMillis() - begin), 0L), "ms")
 
         // start
@@ -416,6 +439,8 @@ object HttpServer {
           response.getWriter.println("" + timeoutJson(node, "start"))
           return
         }
+
+        progress("done")
       }
 
       val nodesJson = nodes.map(_.toJson(expanded = true))


### PR DESCRIPTION
MOTIVATION
Node restart takes significant amount of time.

Default timeout is 5m per node and it is unclear for the user
what is the current overall progress of the operation (consider we
are restarting 10 nodes, for instance).

It would be good to print some progress in CLI like:

    #./dse-mesos.sh node restart 0..9
    stopping node 0 ... done
    starting node 0 ... done
    ...
    stopping node 9 ... done
    starting node 9 ... done

PROPOSED CHANGE

Definition of stopping node for progress is transition of node state 
from starting, running, stopping to starting.

Definition of starting node for progress is transition of node state
from starting to running.

Use streaming (transfer-encoding chunked) to display progress, however it 
requires fundamental backward compatible changes for:
- HTTP Server `/node/restart` 
- CLI should be able to handle chunked responses

when HTTP Server handle request for `/node/restart` and parameter `progress` presents, server
writes "stopping node $id ... " before stopping node and when it has been stopped writes "done",
before starting node it writes "starting node $id ... " and when it is running writes "done",
on client side CLI, handles lines as they arrive and passes them to callback function, when
chunk starts with "{" it parses it and returns control to caller (accumulating everything
after "{" into single string and return it).
Some how easier implementation on CLI side and deadlock due to ordering of starting/stopping nodes impossible
however requires backward compatible changes on HTTP Server and CLI part.

CLI changes:
- handle chunked responses (since there are no direct access to underlying stream thus handle lines)

HTTP Server changes:
- respond in chunks when `progress` parameter preset for `/node/restart` API call
- each chunk (line) will contain item of progress, the last chunk will be JSON (describing error or node list)

NEW OR CHANGED PUBLIC INTERFACES:
- added parameter `onChunk: String => Unit` for net.elodina.mesos.dse.Cli.sendRequest
```
    private[dse] def sendRequest(uri: String, params: Map[String, String], urlPathPrefix: String = "api", parseJson: Boolean = true, onChunk: String => Unit = null): Any
```

- added parameter `progress` to `/node/restart` API call

MIGRATION PLAN AND COMPATIBILITY:
- changes are backward compatible

REJECTED ALTERNATIVES:
- on CLI side poll `/node/list` while restart in progress and watch for node state change, once changed write to console (deadlock possible)
- simplify output to just "restarting node $id ... " and once node changes its state from whatever to running and having different task id output "done" (deadlock possible due to changed ordering)

RESULT: having better user experience, ability to view progress of restart
