### PR TITLE
Automatic migration mechanism for cluster/node state between versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ DataStax Enterprise Mesos Framework
 * [Rolling restart](#rolling-restart)
 * [Memory configuration](#memory-configuration)
 * [Failed node recovery](#failed-node-recovery)
+* [Automatic migration mechanism for state between versions](#automatic-migration-mechanism-for-state-between-versions)
 
 [Navigating the CLI](#navigating-the-cli)
 * [Requesting help](#requesting-help)
@@ -339,6 +340,15 @@ The following failover settings exists:
 --failover-max-delay - max failover delay (option value is required)
 --failover-max-tries - max failover tries to deactivate broker (to reset to unbound pass --failover-max-tries "")
 ```
+
+Automatic migration mechanism for state between versions
+--------------------------------------------------------
+Scheduler of version 0.2.1.3 is able to migrate state between versions for all types
+of storages (file, zk, cassandra) from version 0.2.1.2. For example you are running 0.2.1.2 version and want
+to update to 0.2.1.3 then you have to stop scheduler (for C* storage stop all running
+schedulers that share state table) and then start new scheduler (for C* start schedulers
+sequentially, first one will migrate state table, next will just start without migrating
+anything).
 
 Navigating the CLI
 ==================

--- a/src/main/scala/net/elodina/mesos/dse/CassandraStorage.scala
+++ b/src/main/scala/net/elodina/mesos/dse/CassandraStorage.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.util.Try
 
-class CassandraStorage(port: Int, contactPoints: Seq[String], keyspace: String, stateTable: String) extends Storage {
+class CassandraStorage(port: Int, contactPoints: Seq[String], keyspace: String, stateTable: String, versionTable: String = "version") extends Storage {
 
   import CassandraStorage._
 
@@ -35,7 +35,8 @@ class CassandraStorage(port: Int, contactPoints: Seq[String], keyspace: String, 
       .withPort(port).addContactPoints(contactPoints: _*).build().connect(keyspace)
 
   private val SelectPs = session.prepare(CassandraStorage.selectQuery(stateTable))
-  private val InsertionPs = session.prepare(CassandraStorage.insertionQuery(stateTable))
+  // have to make InsertionPs lazy because it uses fields that could not exist at the moment (e.g. added after migration)
+  private lazy val InsertionPs = session.prepare(CassandraStorage.insertionQuery(stateTable))
   private val DeletionPs = session.prepare(CassandraStorage.deleteQuery(stateTable))
 
   private def stringOrNull[T](value: T): String = {
@@ -256,6 +257,8 @@ class CassandraStorage(port: Int, contactPoints: Seq[String], keyspace: String, 
   }
 
   override def load(): Boolean = {
+    migrate
+
     val boundStatement = SelectPs.bind().setString(Namespace, Config.namespace).setConsistencyLevel(ConsistencyLevel.ONE)
 
     val rows = session.execute(boundStatement).all().asScala
@@ -300,6 +303,28 @@ class CassandraStorage(port: Int, contactPoints: Seq[String], keyspace: String, 
       if (session != null)
         session.close()
     }
+  }
+
+  private[dse] def migrate: Unit = {
+    val verTable = session.getCluster.getMetadata.getKeyspace(keyspace).getTable(versionTable)
+    if (verTable == null) {
+      session.execute(s"create table $keyspace.$versionTable (latest text PRIMARY KEY)")
+      session.execute(s"insert into $keyspace.$versionTable (latest) values ('0.2.1.2')")
+    }
+
+    val schemaVersion: Version = {
+      val result = session.execute(s"select latest from $keyspace.$versionTable")
+      new Version(result.one().getString("latest"))
+    }
+
+    def updateVersion(v: Version): Unit = {
+      session.execute(s"truncate $keyspace.$versionTable")
+      session.execute(s"insert into $keyspace.$versionTable (latest) values ('$v')")
+    }
+
+    Migrator.migrate(schemaVersion, Scheduler.version, Migrator.migrations, updateVersion, m => m.migrateCassandra(session))
+
+    updateVersion(Scheduler.version)
   }
 }
 
@@ -411,92 +436,4 @@ object CassandraStorage{
 
   def selectQuery(table: String) =
     s"SELECT * FROM $table WHERE $Namespace = ${`:`(Namespace)}"
-}
-
-class CassandraStorageMigrator(port: Int, contactPoints: Seq[String], keyspace: String, stateTable: String) {
-  val versionTableName = "version"
-
-  def migrate: Unit = {
-    val session = Cluster.builder().withPort(port).addContactPoints(contactPoints: _*).build().connect(keyspace)
-    try {
-      val versionTable = session.getCluster.getMetadata.getKeyspace(keyspace).getTable(versionTableName)
-      if (versionTable == null) {
-        session.execute(s"create table $keyspace.$versionTableName (latest text PRIMARY KEY)")
-        session.execute(s"insert into $keyspace.$versionTableName (latest) values ('0.2.1.2')")
-      }
-
-      val schemaVersion: Version = {
-        val result = session.execute(s"select latest from $keyspace.$versionTableName")
-        new Version(result.one().getString("latest"))
-      }
-
-      val migrations = Seq(
-        new CassandraMigration0_2_1_3(session, keyspace, stateTable)
-      )
-
-      def updateVersion(v: Version): Unit = {
-        session.execute(s"truncate $keyspace.$versionTableName")
-        session.execute(s"insert into $keyspace.$versionTableName (latest) values ('$v')")
-      }
-
-      Migrator.migrate(schemaVersion, Scheduler.version, migrations, updateVersion)
-
-      updateVersion(Scheduler.version)
-    } finally {
-      session.close()
-    }
-  }
-
-}
-
-class CassandraMigration0_2_1_3(session: Session, keyspace: String, stateTable: String) extends Migration {
-  import CassandraStorage._
-
-  override val version: Version = new Version("0.2.1.3")
-
-  val alters = Seq(
-    s"alter table $keyspace.$stateTable add cluster_jmx_remote boolean",
-    s"alter table $keyspace.$stateTable add cluster_jmx_user text",
-    s"alter table $keyspace.$stateTable add cluster_jmx_password text",
-
-    s"alter table $keyspace.$stateTable add node_failover_delay text",
-    s"alter table $keyspace.$stateTable add node_failover_max_delay text",
-    s"alter table $keyspace.$stateTable add node_failover_max_tries int",
-    s"alter table $keyspace.$stateTable add node_failover_failures int",
-    s"alter table $keyspace.$stateTable add node_failover_failure_time timestamp"
-  )
-
-  override def apply(): Unit = {
-    alters.foreach(session.execute)
-
-    val updatePs = session.prepare(s"""
-            UPDATE $keyspace.$stateTable
-            SET
-            cluster_jmx_remote = false,
-            node_failover_delay = '3m',
-            node_failover_max_delay = '30m',
-            node_failover_failures = 0
-            WHERE
-            namespace = :namespace AND
-              framework_id = :framework_id AND
-              cluster_id = :cluster_id AND
-              node_id = :node_id
-          """)
-
-    val selectPs = session.prepare(s"select namespace, framework_id, cluster_id, node_id, nr_of_nodes from $keyspace.$stateTable")
-
-    val batch = new BatchStatement()
-    val rows = session.execute(selectPs.bind()).all().asScala
-    for (row <- rows) {
-      val update = updatePs.bind()
-        .setString(Namespace, row.getString(Namespace))
-        .setString(FrameworkId, row.getString(FrameworkId))
-        .setString(ClusterId, row.getString(ClusterId))
-        .setString(NodeId, row.getString(NodeId))
-
-      batch add update
-    }
-
-    session execute batch
-  }
 }

--- a/src/main/scala/net/elodina/mesos/dse/CassandraStorage.scala
+++ b/src/main/scala/net/elodina/mesos/dse/CassandraStorage.scala
@@ -322,7 +322,7 @@ class CassandraStorage(port: Int, contactPoints: Seq[String], keyspace: String, 
       session.execute(s"insert into $keyspace.$versionTable (latest) values ('$v')")
     }
 
-    Migrator.migrate(schemaVersion, Scheduler.version, Migrator.migrations, updateVersion, m => m.migrateCassandra(session))
+    Migration.migrate(schemaVersion, Scheduler.version, Migration.migrations, updateVersion, m => m.migrateCassandra(session))
 
     updateVersion(Scheduler.version)
   }

--- a/src/main/scala/net/elodina/mesos/dse/CassandraStorage.scala
+++ b/src/main/scala/net/elodina/mesos/dse/CassandraStorage.scala
@@ -322,7 +322,7 @@ class CassandraStorage(port: Int, contactPoints: Seq[String], keyspace: String, 
       session.execute(s"insert into $keyspace.$versionTable (latest) values ('$v')")
     }
 
-    Migration.migrate(schemaVersion, Scheduler.version, Migration.migrations, updateVersion, m => m.migrateCassandra(session))
+    Migration.migrate(schemaVersion, Scheduler.version, updateVersion, m => m.migrateCassandra(session))
 
     updateVersion(Scheduler.version)
   }

--- a/src/main/scala/net/elodina/mesos/dse/Migration.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Migration.scala
@@ -18,27 +18,21 @@
 
 package net.elodina.mesos.dse
 
-import java.io.File
-import org.I0Itec.zkclient.ZkClient
-import org.I0Itec.zkclient.exception.ZkNodeExistsException
-import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer
+import scala.collection.JavaConverters._
 import net.elodina.mesos.dse.Util.Version
-import scala.util.parsing.json.JSONObject
+import com.datastax.driver.core._
 
 trait Migration {
   val version: Version
-  def apply(): Unit
-}
-
-trait Migrator {
-  def migrate: Unit
+  def migrateJson(json: Map[String, Any]): Map[String, Any]
+  def migrateCassandra(session: Session): Unit
 }
 
 object Migrator {
   import org.apache.log4j.Logger
   private val logger = Logger.getLogger(Migrator.getClass)
 
-  def migrate(from: Version, to: Version, migrations: Seq[Migration], updateVersion: Version => Unit): Unit = {
+  def migrate(from: Version, to: Version, migrations: Seq[Migration], updateVersion: Version => Unit, apply: Migration => Unit): Unit = {
     if (from == to) {
       logger.info("storage schema is up to date")
       return
@@ -52,52 +46,21 @@ object Migrator {
 
     for (m <- applicable) {
       logger.info("applying migration for version " + m.version)
-      m()
+      apply(m)
       updateVersion(m.version)
     }
     logger.info(s"migration from $from to $to completed")
   }
+
+  val migrations = Seq[Migration](
+    new Migration0_2_1_3(Config.cassandraKeyspace, Config.cassandraTable)
+  )
 }
 
-class FileStorageMigrator(file: File) extends Migrator {
-  def migrate = {
-    if (file.exists()) {
-      var schemaVersion: Version = null
-      withJson { json =>
-        val versioned = if (!json.contains("version")) json.updated("version", "0.2.1.2") else json
-        schemaVersion = new Version(versioned("version").asInstanceOf[String])
-        versioned
-      }
+class Migration0_2_1_3(keyspace: String, stateTable: String) extends Migration {
+  override val version: Version = new Version("0.2.1.3")
 
-      val migrations = Seq(
-        mkMigration("0.2.1.3")(JSONMigrations.v0_2_1_3)
-      )
-
-      def updateVersion(v: Version): Unit = withJson { json => json.updated("version", v.toString) }
-
-      Migrator.migrate(schemaVersion, Scheduler.version, migrations, updateVersion)
-
-      updateVersion(Scheduler.version)
-    }
-  }
-
-  def withJson(f: Map[String, Any] => Map[String, Any]): Unit = {
-    if (file.exists()) {
-      val content = Util.IO.readFile(file)
-      val json = Util.parseJsonAsMap(content)
-      Util.IO.writeFile(file, new JSONObject(f(json)).toString(Util.jsonFormatter))
-    }
-  }
-
-  def mkMigration(v: String)(f: Map[String, Any] => Map[String, Any]): Migration = new Migration {
-    override val version: Version = new Version(v)
-
-    override def apply(): Unit = withJson(f)
-  }
-}
-
-object JSONMigrations {
-  def v0_2_1_3(json: Map[String, Any]): Map[String, Any] = {
+  override def migrateJson(json: Map[String, Any]): Map[String, Any] = {
     // update cluster, add jmxRemote false
     val json1 = if (json.contains("clusters")) {
       val clusters = json("clusters").asInstanceOf[List[Map[String, Object]]]
@@ -112,68 +75,54 @@ object JSONMigrations {
 
     json2
   }
-}
 
-trait ZkMigratorHelpers {
-  val path: String
+  val alters = Seq(
+    s"alter table $keyspace.$stateTable add cluster_jmx_remote boolean",
+    s"alter table $keyspace.$stateTable add cluster_jmx_user text",
+    s"alter table $keyspace.$stateTable add cluster_jmx_password text",
 
-  def withJson(client: ZkClient)(f: Map[String, Any] => Map[String, Any]) {
-    val json = {
-      val bytes: Array[Byte] = client.readData(path, true).asInstanceOf[Array[Byte]]
-      if (bytes != null) Util.parseJsonAsMap(new String(bytes, "utf-8"))
-      else Map.empty[String, Any]
+    s"alter table $keyspace.$stateTable add node_failover_delay text",
+    s"alter table $keyspace.$stateTable add node_failover_max_delay text",
+    s"alter table $keyspace.$stateTable add node_failover_max_tries int",
+    s"alter table $keyspace.$stateTable add node_failover_failures int",
+    s"alter table $keyspace.$stateTable add node_failover_failure_time timestamp"
+  )
+
+  override def migrateCassandra(session: Session): Unit = {
+    alters.foreach(session.execute)
+
+    val updatePs = session.prepare(s"""
+          UPDATE $keyspace.$stateTable
+          SET
+          cluster_jmx_remote = false,
+          node_failover_delay = '3m',
+          node_failover_max_delay = '30m',
+          node_failover_failures = 0
+          WHERE
+          namespace = :namespace AND
+            framework_id = :framework_id AND
+            cluster_id = :cluster_id AND
+            node_id = :node_id
+        """)
+
+    val selectPs = session.prepare(s"select namespace, framework_id, cluster_id, node_id, nr_of_nodes from $keyspace.$stateTable")
+
+    import CassandraStorage._
+
+    val batch = new BatchStatement()
+    batch.setConsistencyLevel(ConsistencyLevel.ONE)
+    val rows = session.execute(selectPs.bind()).all().asScala
+    for (row <- rows) {
+      val update = updatePs.bind()
+        .setString(Namespace, row.getString(Namespace))
+        .setString(FrameworkId, row.getString(FrameworkId))
+        .setString(ClusterId, row.getString(ClusterId))
+        .setString(NodeId, row.getString(NodeId))
+
+      batch add update
     }
 
-    val json1 = f(json)
-
-    val encoded = new JSONObject(json1).toString(Util.jsonFormatter).getBytes("utf-8")
-    try {
-      client.createPersistent(path, encoded)
-    } catch {
-      case e: ZkNodeExistsException => client.writeData(path, encoded)
-    }
-  }
-}
-
-class ZkStorageMigrator(zk: String) extends Migrator with ZkMigratorHelpers {
-  val (zkConnect, path) = zk.span(_ != '/')
-
-  override def migrate: Unit = {
-    withClient { client =>
-      if (path != "") client.createPersistent(path, true)
-
-      var schemaVersion: Version = null
-      withJson(client) { json =>
-        val versioned = if (!json.contains("version")) json.updated("version", "0.2.1.2") else json
-        schemaVersion = new Version(versioned("version").asInstanceOf[String])
-        versioned
-      }
-
-      val migrations = Seq(
-        new ZkMigraiton0_2_1_3(client, path)
-      )
-
-      def updateVersion(v: Version) = withJson(client) { json => json.updated("version", v.toString) }
-
-      Migrator.migrate(schemaVersion, Scheduler.version, migrations, updateVersion)
-
-      updateVersion(Scheduler.version)
-    }
-  }
-
-  private[dse] def withClient[T](f: ZkClient => T): T = {
-    val c = zkClient
-    try { f(c) } finally { c.close() }
-  }
-
-  private[dse] def zkClient: ZkClient = new ZkClient(zkConnect, 30000, 30000, new BytesPushThroughSerializer)
-}
-
-class ZkMigraiton0_2_1_3(client: ZkClient, override val path: String) extends Migration with ZkMigratorHelpers {
-  override val version: Version = new Version("0.2.1.3")
-
-  override def apply(): Unit = {
-    withJson(client)(JSONMigrations.v0_2_1_3)
+    session execute batch
   }
 }
 

--- a/src/main/scala/net/elodina/mesos/dse/Migration.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Migration.scala
@@ -28,9 +28,9 @@ trait Migration {
   def migrateCassandra(session: Session): Unit
 }
 
-object Migrator {
+object Migration {
   import org.apache.log4j.Logger
-  private val logger = Logger.getLogger(Migrator.getClass)
+  private val logger = Logger.getLogger(Migration.getClass)
 
   def migrate(from: Version, to: Version, migrations: Seq[Migration], updateVersion: Version => Unit, apply: Migration => Unit): Unit = {
     if (from == to) {

--- a/src/main/scala/net/elodina/mesos/dse/Migration.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Migration.scala
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.elodina.mesos.dse
+
+import java.io.File
+import org.I0Itec.zkclient.ZkClient
+import org.I0Itec.zkclient.exception.ZkNodeExistsException
+import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer
+import net.elodina.mesos.dse.Util.Version
+import scala.util.parsing.json.JSONObject
+
+trait Migration {
+  val version: Version
+  def apply(): Unit
+}
+
+trait Migrator {
+  def migrate: Unit
+}
+
+object Migrator {
+  import org.apache.log4j.Logger
+  private val logger = Logger.getLogger(Migrator.getClass)
+
+  def migrate(from: Version, to: Version, migrations: Seq[Migration], updateVersion: Version => Unit): Unit = {
+    if (from == to) {
+      logger.info("storage schema is up to date")
+      return
+    }
+
+    val applicable = migrations
+      .filter { m => m.version > from && m.version <= to}
+      .sortBy(_.version)
+
+    logger.info(s"migrating storage from $from to $to")
+
+    for (m <- applicable) {
+      logger.info("applying migration for version " + m.version)
+      m()
+      updateVersion(m.version)
+    }
+    logger.info(s"migration from $from to $to completed")
+  }
+}
+
+class FileStorageMigrator(file: File) extends Migrator {
+  def migrate = {
+    if (file.exists()) {
+      var schemaVersion: Version = null
+      withJson { json =>
+        val versioned = if (!json.contains("version")) json.updated("version", "0.2.1.2") else json
+        schemaVersion = new Version(versioned("version").asInstanceOf[String])
+        versioned
+      }
+
+      val migrations = Seq(
+        mkMigration("0.2.1.3")(JSONMigrations.v0_2_1_3)
+      )
+
+      def updateVersion(v: Version): Unit = withJson { json => json.updated("version", v.toString) }
+
+      Migrator.migrate(schemaVersion, Scheduler.version, migrations, updateVersion)
+
+      updateVersion(Scheduler.version)
+    }
+  }
+
+  def withJson(f: Map[String, Any] => Map[String, Any]): Unit = {
+    if (file.exists()) {
+      val content = Util.IO.readFile(file)
+      val json = Util.parseJsonAsMap(content)
+      Util.IO.writeFile(file, new JSONObject(f(json)).toString(Util.jsonFormatter))
+    }
+  }
+
+  def mkMigration(v: String)(f: Map[String, Any] => Map[String, Any]): Migration = new Migration {
+    override val version: Version = new Version(v)
+
+    override def apply(): Unit = withJson(f)
+  }
+}
+
+object JSONMigrations {
+  def v0_2_1_3(json: Map[String, Any]): Map[String, Any] = {
+    // update cluster, add jmxRemote false
+    val json1 = if (json.contains("clusters")) {
+      val clusters = json("clusters").asInstanceOf[List[Map[String, Object]]]
+      json.updated("clusters", clusters.map { cluster => cluster.updated("jmxRemote", false) })
+    } else json
+
+    // update nodes, add failover delay 3m and maxDelay 30m
+    val json2 = if (json1.contains("nodes")) {
+      val nodes = json1("nodes").asInstanceOf[List[Map[String, Object]]]
+      json1.updated("nodes", nodes.map { node => node.updated("failover", Map("delay" -> "3m", "maxDelay" -> "30m")) })
+    } else json1
+
+    json2
+  }
+}
+
+trait ZkMigratorHelpers {
+  val path: String
+
+  def withJson(client: ZkClient)(f: Map[String, Any] => Map[String, Any]) {
+    val json = {
+      val bytes: Array[Byte] = client.readData(path, true).asInstanceOf[Array[Byte]]
+      if (bytes != null) Util.parseJsonAsMap(new String(bytes, "utf-8"))
+      else Map.empty[String, Any]
+    }
+
+    val json1 = f(json)
+
+    val encoded = new JSONObject(json1).toString(Util.jsonFormatter).getBytes("utf-8")
+    try {
+      client.createPersistent(path, encoded)
+    } catch {
+      case e: ZkNodeExistsException => client.writeData(path, encoded)
+    }
+  }
+}
+
+class ZkStorageMigrator(zk: String) extends Migrator with ZkMigratorHelpers {
+  val (zkConnect, path) = zk.span(_ != '/')
+
+  override def migrate: Unit = {
+    withClient { client =>
+      if (path != "") client.createPersistent(path, true)
+
+      var schemaVersion: Version = null
+      withJson(client) { json =>
+        val versioned = if (!json.contains("version")) json.updated("version", "0.2.1.2") else json
+        schemaVersion = new Version(versioned("version").asInstanceOf[String])
+        versioned
+      }
+
+      val migrations = Seq(
+        new ZkMigraiton0_2_1_3(client, path)
+      )
+
+      def updateVersion(v: Version) = withJson(client) { json => json.updated("version", v.toString) }
+
+      Migrator.migrate(schemaVersion, Scheduler.version, migrations, updateVersion)
+
+      updateVersion(Scheduler.version)
+    }
+  }
+
+  private[dse] def withClient[T](f: ZkClient => T): T = {
+    val c = zkClient
+    try { f(c) } finally { c.close() }
+  }
+
+  private[dse] def zkClient: ZkClient = new ZkClient(zkConnect, 30000, 30000, new BytesPushThroughSerializer)
+}
+
+class ZkMigraiton0_2_1_3(client: ZkClient, override val path: String) extends Migration with ZkMigratorHelpers {
+  override val version: Version = new Version("0.2.1.3")
+
+  override def apply(): Unit = {
+    withJson(client)(JSONMigrations.v0_2_1_3)
+  }
+}
+

--- a/src/main/scala/net/elodina/mesos/dse/Migration.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Migration.scala
@@ -32,7 +32,7 @@ object Migration {
   import org.apache.log4j.Logger
   private val logger = Logger.getLogger(Migration.getClass)
 
-  def migrate(from: Version, to: Version, migrations: Seq[Migration], updateVersion: Version => Unit, apply: Migration => Unit): Unit = {
+  def migrate(from: Version, to: Version, updateVersion: Version => Unit, apply: Migration => Unit): Unit = {
     if (from == to) {
       logger.info("storage schema is up to date")
       return

--- a/src/main/scala/net/elodina/mesos/dse/Nodes.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Nodes.scala
@@ -129,20 +129,10 @@ object Nodes {
 
   private[dse] def newStorage(storage: String): Storage = {
     storage.split(":", 3) match {
-      case Array("file", fileName) =>
-        val file = new File(fileName)
-        new FileStorageMigrator(file).migrate
-        FileStorage(file)
-
-      case Array("zk", zk) =>
-        new ZkStorageMigrator(zk).migrate
-        ZkStorage(zk)
-
+      case Array("file", fileName) => FileStorage(new File(fileName))
+      case Array("zk", zk) => ZkStorage(zk)
       case Array("cassandra", port, contactPoints) =>
-        val points = contactPoints.split(",").map(_.trim)
-        new CassandraStorageMigrator(port.toInt, points, Config.cassandraKeyspace, Config.cassandraTable).migrate
-        new CassandraStorage(port.toInt, points, Config.cassandraKeyspace, Config.cassandraTable)
-
+        new CassandraStorage(port.toInt, contactPoints.split(",").map(_.trim), Config.cassandraKeyspace, Config.cassandraTable)
       case _ => throw new IllegalArgumentException(s"Unsupported storage: $storage")
     }
   }

--- a/src/main/scala/net/elodina/mesos/dse/Scheduler.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Scheduler.scala
@@ -30,13 +30,15 @@ import scala.collection.JavaConversions._
 import scala.concurrent.duration.Duration
 import scala.language.postfixOps
 
-import Util.Str
+import Util.{Str, Version}
 import scala.collection.mutable.ListBuffer
 import java.util.{Collections, Date}
 
 object Scheduler extends org.apache.mesos.Scheduler with Constraints[Node] {
   private[dse] val logger = Logger.getLogger(this.getClass)
   private var driver: SchedulerDriver = null
+
+  val version = new Version("0.2.1.3")
 
   def start() {
     initLogging()

--- a/src/main/scala/net/elodina/mesos/dse/Storage.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Storage.scala
@@ -23,8 +23,6 @@ import org.I0Itec.zkclient.ZkClient
 import org.I0Itec.zkclient.exception.ZkNodeExistsException
 import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer
 
-import scala.util.parsing.json.JSONObject
-
 trait Storage {
   def save()
 

--- a/src/main/scala/net/elodina/mesos/dse/Storage.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Storage.scala
@@ -66,7 +66,7 @@ case class FileStorage(file: File) extends Storage {
       def updateVersion(v: Version): Unit = withJson { json => json.updated("version", v.toString) }
 
       var json: Map[String, Any] = readJson
-      Migrator.migrate(schemaVersion, Scheduler.version, Migrator.migrations, v => (), m => json = m.migrateJson(json))
+      Migration.migrate(schemaVersion, Scheduler.version, Migration.migrations, v => (), m => json = m.migrateJson(json))
       writeJson(json)
 
       updateVersion(Scheduler.version)
@@ -118,7 +118,7 @@ case class ZkStorage[T](zk: String) extends Storage {
       def updateVersion(v: Version) = withJson(client) { json => json.updated("version", v.toString) }
 
       var json = readJson(client)
-      Migrator.migrate(schemaVersion, Scheduler.version, Migrator.migrations, v => (), m => json = m.migrateJson(json))
+      Migration.migrate(schemaVersion, Scheduler.version, Migration.migrations, v => (), m => json = m.migrateJson(json))
       writeJson(client, json)
 
       updateVersion(Scheduler.version)

--- a/src/main/scala/net/elodina/mesos/dse/Storage.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Storage.scala
@@ -66,7 +66,7 @@ case class FileStorage(file: File) extends Storage {
       def updateVersion(v: Version): Unit = withJson { json => json.updated("version", v.toString) }
 
       var json: Map[String, Any] = readJson
-      Migration.migrate(schemaVersion, Scheduler.version, Migration.migrations, v => (), m => json = m.migrateJson(json))
+      Migration.migrate(schemaVersion, Scheduler.version, v => (), m => json = m.migrateJson(json))
       writeJson(json)
 
       updateVersion(Scheduler.version)
@@ -118,7 +118,7 @@ case class ZkStorage[T](zk: String) extends Storage {
       def updateVersion(v: Version) = withJson(client) { json => json.updated("version", v.toString) }
 
       var json = readJson(client)
-      Migration.migrate(schemaVersion, Scheduler.version, Migration.migrations, v => (), m => json = m.migrateJson(json))
+      Migration.migrate(schemaVersion, Scheduler.version, v => (), m => json = m.migrateJson(json))
       writeJson(client, json)
 
       updateVersion(Scheduler.version)

--- a/src/main/scala/net/elodina/mesos/dse/Storage.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Storage.scala
@@ -22,6 +22,8 @@ import java.io.File
 import org.I0Itec.zkclient.ZkClient
 import org.I0Itec.zkclient.exception.ZkNodeExistsException
 import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer
+import net.elodina.mesos.dse.Util.Version
+import scala.util.parsing.json.JSONObject
 
 trait Storage {
   def save()
@@ -45,10 +47,42 @@ case class FileStorage(file: File) extends Storage {
 
   override def load(): Boolean = {
     if (file.exists()) {
+      migrate
       val json = Util.IO.readFile(file)
       Nodes.fromJson(Util.parseJsonAsMap(json))
       true
     } else false
+  }
+
+  private[dse] def migrate: Unit = {
+    if (file.exists()) {
+      var schemaVersion: Version = null
+      withJson { json =>
+        val versioned = if (!json.contains("version")) json.updated("version", "0.2.1.2") else json
+        schemaVersion = new Version(versioned("version").asInstanceOf[String])
+        versioned
+      }
+
+      def updateVersion(v: Version): Unit = withJson { json => json.updated("version", v.toString) }
+
+      var json: Map[String, Any] = readJson
+      Migrator.migrate(schemaVersion, Scheduler.version, Migrator.migrations, v => (), m => json = m.migrateJson(json))
+      writeJson(json)
+
+      updateVersion(Scheduler.version)
+    }
+  }
+
+  def readJson: Map[String, Any] =
+    if (file.exists()) Util.parseJsonAsMap(Util.IO.readFile(file))
+    else Map.empty[String, Any]
+
+  def writeJson(json: Map[String, Any]): Unit = {
+    Util.IO.writeFile(file, new JSONObject(json).toString(Util.jsonFormatter))
+  }
+
+  def withJson(f: Map[String, Any] => Map[String, Any]): Unit = {
+    if (file.exists()) Util.IO.writeFile(file, new JSONObject(f(readJson)).toString(Util.jsonFormatter))
   }
 }
 
@@ -56,47 +90,68 @@ case class ZkStorage[T](zk: String) extends Storage {
   val (zkConnect, path) = zk.span(_ != '/')
   createChrootIfRequired()
 
-  private def createChrootIfRequired() {
-    if (path != "") {
-      val client = zkClient
-      try {
-        client.createPersistent(path, true)
-      }
-      finally {
-        client.close()
-      }
-    }
-  }
-
-  private def zkClient: ZkClient = new ZkClient(zkConnect, 30000, 30000, new BytesPushThroughSerializer)
-
   override def save() {
-    val json = Nodes.toJson
-    val client = zkClient
-    val encoded = json.toString().getBytes("utf-8")
-    try {
-      client.createPersistent(path, encoded)
-    } catch {
-      case e: ZkNodeExistsException => client.writeData(path, encoded)
-    }
-    finally {
-      client.close()
-    }
+    withClient { client => write(client, Nodes.toJson.toString().getBytes("utf-8")) }
   }
 
   override def load(): Boolean = {
-    val client = zkClient
-    try {
-      val bytes: Array[Byte] = client.readData(path, true).asInstanceOf[Array[Byte]]
-      if (bytes != null) {
-        val map = Util.parseJsonAsMap(new String(bytes, "utf-8"))
-        Nodes.fromJson(map)
+    migrate
+
+    withClient { client =>
+      val json = readJson(client)
+      if (json.nonEmpty) {
+        Nodes.fromJson(json)
         true
       } else false
-
-    } finally {
-      client.close()
     }
   }
+
+  private[dse] def migrate: Unit = {
+    withClient { client =>
+      var schemaVersion: Version = null
+      withJson(client) { json =>
+        val versioned = if (!json.contains("version")) json.updated("version", "0.2.1.2") else json
+        schemaVersion = new Version(versioned("version").asInstanceOf[String])
+        versioned
+      }
+
+      def updateVersion(v: Version) = withJson(client) { json => json.updated("version", v.toString) }
+
+      var json = readJson(client)
+      Migrator.migrate(schemaVersion, Scheduler.version, Migrator.migrations, v => (), m => json = m.migrateJson(json))
+      writeJson(client, json)
+
+      updateVersion(Scheduler.version)
+    }
+  }
+
+  private def createChrootIfRequired(): Unit = if (path != "") withClient(_.createPersistent(path, true))
+
+  private[dse] def zkClient: ZkClient = new ZkClient(zkConnect, 30000, 30000, new BytesPushThroughSerializer)
+
+  private[dse] def withClient[T](f: ZkClient => T): T = {
+    val c = zkClient
+    try { f(c) } finally { c.close() }
+  }
+
+  private def write(client: ZkClient, bytes: Array[Byte]) {
+    try {
+      client.createPersistent(path, bytes)
+    } catch {
+      case e: ZkNodeExistsException => client.writeData(path, bytes)
+    }
+  }
+
+  private def readJson(client: ZkClient): Map[String, Any] = {
+    val bytes: Array[Byte] = client.readData(path, true).asInstanceOf[Array[Byte]]
+    if (bytes != null) Util.parseJsonAsMap(new String(bytes, "utf-8"))
+    else Map.empty[String, Any]
+  }
+
+  private def writeJson(client: ZkClient, json: Map[String, Any]): Unit = {
+    write(client, new JSONObject(json).toString(Util.jsonFormatter).getBytes("utf-8"))
+  }
+
+  private def withJson(client: ZkClient)(f: Map[String, Any] => Map[String, Any]): Unit = writeJson(client, f(readJson(client)))
 }
 

--- a/src/main/test/net/elodina/mesos/dse/UtilTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/UtilTest.scala
@@ -283,6 +283,33 @@ class UtilTest {
     assertEquals("0", "" + new Range("0..0"))
   }
 
+  @Test
+  def Version_init {
+    assertEquals(List(), new Version().asList)
+    assertEquals(List(1,0), new Version(1,0).asList)
+    assertEquals(List(1,2,3,4), new Version("1.2.3.4").asList)
+
+    try { new Version(" "); fail() }
+    catch { case e: IllegalArgumentException => }
+
+    try { new Version("."); fail() }
+    catch { case e: IllegalArgumentException => }
+
+    try { new Version("a"); fail() }
+    catch { case e: IllegalArgumentException => }
+  }
+
+  @Test
+  def Version_compareTo {
+    assertEquals(0, new Version().compareTo(new Version()))
+    assertEquals(0, new Version(0).compareTo(new Version(0)))
+
+    assertTrue(new Version(0).compareTo(new Version(1)) < 0)
+    assertTrue(new Version(0).compareTo(new Version(0, 0)) < 0)
+
+    assertTrue(new Version(0, 9, 0, 0).compareTo(new Version(0, 8, 2, 0)) > 0)
+  }
+
   // BindAddress
   @Test
   def BindAddress_init {

--- a/vagrant/cassandra_schema.cql
+++ b/vagrant/cassandra_schema.cql
@@ -3,6 +3,9 @@ CREATE KEYSPACE IF NOT EXISTS dse_mesos
 
 USE dse_mesos;
 
+CREATE TABLE IF NOT EXISTS version (latest text PRIMARY KEY);
+INSERT INTO version (latest) VALUES ('0.2.1.3');
+
 CREATE TABLE IF NOT EXISTS dse_mesos_framework(
         namespace text,
         framework_id text,


### PR DESCRIPTION
MOTIVATION:
We are going to introduce new config concepts/options. It will definitely change json format and C* storage table format. And when the user upgrades the Scheduler it's json state/c* table should be migrated automatically to the new format.

For that purpose we need to have some simple mechanism to migrate json state
to the newer version (only in forward direction).

The proposed approach is following:
1. add Scheduler.version: Version field, containing current version.
2. add version attribute to json state (if absent, we assume - 0.2.1.2 or current on the moment of the implementation);
3. if Scheduler.version is greater then json state version, we apply a series of migration classes, matching those version interval.
4. log about applied migrations;

Open question: need to think. May be we will need to support migrations in both direction forward and backward. This will allow the user to downgrade the scheduler, if required.

PROPOSED CHANGE:

NOTE: because C* storage state table are being shared between many DSE frameworks with different namespaces implementation assumes all those frameworks will be restarted simultaneously. Framework that will be started at first will perform data migration, then when next framework starts it doesn't perform migration cause it has been done by prev framework.

NOTE: default version is 0.2.1.2

Scheduler of version 0.2.1.3 is able to migrate state between versions for all types
of storages (file, zk, cassandra) from version 0.2.1.2. For example you are running 0.2.1.2 version and want to update to 0.2.1.3 then you have to stop scheduler (for C* storage stop all running
schedulers that share state table) and then start new scheduler (for C* start schedulers
sequentially, first one will migrate state table, next will just start without migrating
anything).

How C* state migration works:
- if table version not exist it will be created, assuming current version is 0.2.1.2
- migration for 0.2.1.3 will alter state table

    alter table dse_mesos.dse_mesos_framework add cluster_jmx_remote boolean;
    alter table dse_mesos.dse_mesos_framework add cluster_jmx_user text;
    alter table dse_mesos.dse_mesos_framework add cluster_jmx_password text;

    alter table dse_mesos.dse_mesos_framework add node_failover_delay text;
    alter table dse_mesos.dse_mesos_framework add node_failover_max_delay text;
    alter table dse_mesos.dse_mesos_framework add node_failover_max_tries int;
    alter table dse_mesos.dse_mesos_framework add node_failover_failures int;
    alter table dse_mesos.dse_mesos_framework add node_failover_failure_time timestamp ;

  and also will set default values 

    update dse_mesos.dse_mesos_framework 
    set 
      cluster_jmx_remote = false, 
      node_failover_delay = '3m', 
      node_failover_max_delay = '30m', 
      node_failover_failures = 0 
    where 
      namespace = NAMESPACE and 
      framework_id = FRAMEWORK_ID and 
      cluster_id = CLUSTER_ID and 
      node_id = NODE_ID ;

- after each migration, version table will be update with corresponding migration version

In order to update version, version table truncated and then inserted latest version value.

How Zookeeper state migration works:
- create path if not empty 
- fetch znode content for given path and parse it as JSON
- if version is missing assumed default version 0.2.1.2
- applied JSON transformation which will add jmxRemote property (value false), and failover property with delay, maxDelay properties (3m and 30m corresponding)
- save updated JSON into znode and update version in JSON

How file state migration works, same as for Zookeeper except stored into file.

NEW OR CHANGED PUBLIC INTERFACES:

    trait Migration {
      val version: Version
      def migrateJson(json: Map[String, Any]): Map[String, Any]
      def migrateCassandra(session: Session): Unit
    }

MIGRATION PLAN AND COMPATIBILITY:
- all changes are compatible

REJECTED ALTERNATIVES:
- C* state table: 
  - one table for each version (in order not to force stop other running schedulers, obvious disadvantages difficult to manage, very complicated operations)
  - one state table but with JSON fields (describing node), unfortunately approach doesn't allow to query data

RESULT: better user experience, scheduler of version 0.2.1.3 is able to migrate state from version 0.2.1.2
