### PR TITLE
Fixed zk storage matching

### DIFF
--- a/src/main/scala/net/elodina/mesos/dse/Nodes.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Nodes.scala
@@ -130,7 +130,7 @@ object Nodes {
   private[dse] def newStorage(storage: String): Storage = {
     storage.split(":", 3) match {
       case Array("file", fileName) => FileStorage(new File(fileName))
-      case Array("zk", zk) => ZkStorage(zk)
+      case Array("zk", zk @ _*) => ZkStorage(zk.mkString(":"))
       case Array("cassandra", port, contactPoints) =>
         new CassandraStorage(port.toInt, contactPoints.split(",").map(_.trim), Config.cassandraKeyspace, Config.cassandraTable)
       case _ => throw new IllegalArgumentException(s"Unsupported storage: $storage")


### PR DESCRIPTION
MOTIVATION:
When zk storage specified with port Nodes#newStorage unable to match
on `case Array("zk", zk)` because there are 3 elements in array after
split (zk, master, 2181/dse-mesos).

PROPOSED CHANGE:
Match only on "zk" prefix and concatenate rest of the array.

RESULT: ability to specify port for zk storage
