### PR TITLE
added SOLR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ DataStax Enterprise Mesos Framework
 * [Memory configuration](#memory-configuration)
 * [Failed node recovery](#failed-node-recovery)
 * [Automatic migration mechanism for state between versions](#automatic-migration-mechanism-for-state-between-versions)
+* [Upgrading scheduler](#upgrading-scheduler)
+* [Launching SOLR](#launching-solr)
 
 [Navigating the CLI](#navigating-the-cli)
 * [Requesting help](#requesting-help)
@@ -349,6 +351,38 @@ to update to 0.2.1.3 then you have to stop scheduler (for C* storage stop all ru
 schedulers that share state table) and then start new scheduler (for C* start schedulers
 sequentially, first one will migrate state table, next will just start without migrating
 anything).
+
+Launching SOLR
+--------------
+
+Just pass option `--solr-enabled true` when creating
+
+```
+./dse-mesos.sh node add 0 --solr-enabled true
+
+node added:
+  id: 0
+  state: idle
+  topology: cluster:default, dc:default, rack:default
+  resources: cpu:0.5, mem:512
+  seed: false
+  solr: true
+  dirs: data:<auto>, commit:<auto>, caches:<auto>
+  failover: delay:3m, max-delay:30m
+  stickiness: period:30m
+```
+
+or updating node configuration via CLI (NOTE: `solr: true` means node with SOLR),
+
+```
+./dse-mesos.sh node update 0 --solr-enabled true
+```
+
+in order to disable launching SOLR on node pass `--solr-enabled false` (don't forget to restart updated node).
+
+SOLR requires two ports `HTTP` and `Shard`, configure them via `./dse-mesos cluster <add | update>` with options
+`--solr-http-port` and `--solr-shard-port`.
+
 
 Navigating the CLI
 ==================

--- a/src/main/scala/net/elodina/mesos/dse/CassandraStorage.scala
+++ b/src/main/scala/net/elodina/mesos/dse/CassandraStorage.scala
@@ -139,6 +139,7 @@ class CassandraStorage(port: Int, contactPoints: Seq[String], keyspace: String, 
             .setString(NodeSeedConstraints, Util.formatConstraints(node.seedConstraints)).setString(NodeDataFileDirs, node.dataFileDirs).setString(NodeCommitLogDir, node.commitLogDir)
             .setString(NodeSavedCachesDir, node.savedCachesDir).setMap(NodeCassandraDotYaml, node.cassandraDotYaml.asJava).setMap(NodeAddressDotYaml, node.addressDotYaml.asJava)
             .setString(NodeCassandraJvmOptions, node.cassandraJvmOptions).setBool(NodeModified, node.modified)
+            .setBool(NodeSolrEnabled, node.solrEnabled)
             .setLong(UsingTimestamp, tg.next())
 
           batch.add(boundStatement)
@@ -253,6 +254,8 @@ class CassandraStorage(port: Int, contactPoints: Seq[String], keyspace: String, 
     node.modified = row.getBool(NodeModified)
 
     node.failover = failover(row)
+
+    node.solrEnabled = row.getBool(NodeSolrEnabled)
 
     node
   }
@@ -375,6 +378,7 @@ object CassandraStorage{
   val NodeFailoverMaxTries = "node_failover_max_tries"
   val NodeFailoverFailures = "node_failover_failures"
   val NodeFailoverFailureTime = "node_failover_failure_time"
+  val NodeSolrEnabled = "node_solr_enabled"
 
   // not part of the table schema
   val UsingTimestamp = "using_timestamp"
@@ -424,7 +428,8 @@ object CassandraStorage{
     NodeFailoverMaxDelay,
     NodeFailoverMaxTries,
     NodeFailoverFailures,
-    NodeFailoverFailureTime
+    NodeFailoverFailureTime,
+    NodeSolrEnabled
   )
 
   private def `:`(field: String) = ":" + field

--- a/src/main/scala/net/elodina/mesos/dse/ClusterCli.scala
+++ b/src/main/scala/net/elodina/mesos/dse/ClusterCli.scala
@@ -88,6 +88,8 @@ object ClusterCli {
     parser.accepts("cql-port", "CQL port.").withRequiredArg().ofType(classOf[String])
     parser.accepts("thrift-port", "Thrift port.").withRequiredArg().ofType(classOf[String])
     parser.accepts("agent-port", "DataStax agent port.").withRequiredArg().ofType(classOf[String])
+    parser.accepts("solr-http-port", "SOLR HTTP port.").withRequiredArg().ofType(classOf[String])
+    parser.accepts("solr-shard-port", "SOLR shard port.").withRequiredArg().ofType(classOf[String])
 
     if (help) {
       printLine(s"${cmd.capitalize} cluster \nUsage: cluster $cmd <id> [options]\n")
@@ -118,6 +120,8 @@ object ClusterCli {
     val cqlPort = options.valueOf("cql-port").asInstanceOf[String]
     val thriftPort = options.valueOf("thrift-port").asInstanceOf[String]
     val agentPort = options.valueOf("agent-port").asInstanceOf[String]
+    val solrHttpPort = options.valueOf("solr-http-port").asInstanceOf[String]
+    val solrShardPort = options.valueOf("solr-shard-port").asInstanceOf[String]
 
     val params = mutable.HashMap("cluster" -> id)
 
@@ -132,6 +136,8 @@ object ClusterCli {
     if (cqlPort != null) params("cqlPort") = cqlPort
     if (thriftPort != null) params("thriftPort") = thriftPort
     if (agentPort != null) params("agentPort") = agentPort
+    if (solrHttpPort != null) params("solrHttpPort") = solrHttpPort
+    if (solrShardPort != null) params("solrShardPort") = solrShardPort
 
     var json: Map[String, Any] = null
     try { json = Cli.sendRequest(s"/cluster/$cmd", params.toMap).asInstanceOf[Map[String, Any]] }

--- a/src/main/scala/net/elodina/mesos/dse/Migration.scala
+++ b/src/main/scala/net/elodina/mesos/dse/Migration.scala
@@ -71,7 +71,11 @@ private class M_0_2_1_3 extends Migration {
     // update nodes, add failover delay 3m and maxDelay 30m
     val json2 = if (json1.contains("nodes")) {
       val nodes = json1("nodes").asInstanceOf[List[Map[String, Object]]]
-      json1.updated("nodes", nodes.map { node => node.updated("failover", Map("delay" -> "3m", "maxDelay" -> "30m")) })
+      json1.updated("nodes", nodes.map { node =>
+        node
+          .updated("failover", Map("delay" -> "3m", "maxDelay" -> "30m"))
+          .updated("solrEnabled", false)
+      })
     } else json1
 
     json2
@@ -90,7 +94,9 @@ private class M_0_2_1_3 extends Migration {
       s"alter table $keyspace.$table add node_failover_max_delay text",
       s"alter table $keyspace.$table add node_failover_max_tries int",
       s"alter table $keyspace.$table add node_failover_failures int",
-      s"alter table $keyspace.$table add node_failover_failure_time timestamp"
+      s"alter table $keyspace.$table add node_failover_failure_time timestamp",
+
+      s"alter table $keyspace.$table add node_solr_enabled boolean"
     )
     alters.foreach(session.execute)
 

--- a/src/main/scala/net/elodina/mesos/dse/NodeCli.scala
+++ b/src/main/scala/net/elodina/mesos/dse/NodeCli.scala
@@ -120,6 +120,8 @@ object NodeCli {
     parser.accepts("failover-max-delay", "max failover delay. See failoverDelay.").withRequiredArg().ofType(classOf[String])
     parser.accepts("failover-max-tries", "max failover tries. Default - none").withRequiredArg().ofType(classOf[String])
 
+    parser.accepts("solr-enabled", "Enable SOLR for node. Default - false").withRequiredArg().ofType(classOf[java.lang.Boolean])
+
     if (help) {
       printLine(s"${cmd.capitalize} node \nUsage: node $cmd <id> [options]\n")
       parser.printHelpOn(out)
@@ -164,6 +166,8 @@ object NodeCli {
     val failoverMaxDelay = options.valueOf("failover-max-delay").asInstanceOf[String]
     val failoverMaxTries = options.valueOf("failover-max-tries").asInstanceOf[String]
 
+    val solrEnabled = options.valueOf("solr-enabled").asInstanceOf[java.lang.Boolean]
+
     val params = new mutable.HashMap[String, String]()
     params("node") = expr
     if (cluster != null) params("cluster") = cluster
@@ -191,6 +195,8 @@ object NodeCli {
     if (failoverDelay != null) params.put("failoverDelay", failoverDelay)
     if (failoverMaxDelay != null) params.put("failoverMaxDelay", failoverMaxDelay)
     if (failoverMaxTries != null) params.put("failoverMaxTries", failoverMaxTries)
+
+    if (solrEnabled != null) params.put("solrEnabled", "" + solrEnabled)
 
     var nodesJson: List[Any] = null
     try { nodesJson = Cli.sendRequest(s"/node/$cmd", params.toMap).asInstanceOf[List[Any]] }
@@ -346,6 +352,7 @@ object NodeCli {
     printLine(s"topology: ${nodeTopology(node)}", indent)
     printLine(s"resources: ${nodeResources(node)}", indent)
     printLine(s"seed: ${node.seed}", indent)
+    printLine(s"solr: ${node.solrEnabled}", indent)
 
     if (node.jvmOptions != null) printLine(s"jvm-options: ${node.jvmOptions}", indent)
 

--- a/src/main/test/net/elodina/mesos/dse/CassandraStorageTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/CassandraStorageTest.scala
@@ -43,7 +43,7 @@ object CassandraStorageTest {
                          jvmOptions: String, rack: String, dc: String, constraints: Map[String, List[Constraint]],
                          seedConstraints: Map[String, List[Constraint]], dataFileDirs: String, commitLogDir: String,
                          savedCachesDir: String, cassandraDotYaml: Map[String, String], addressDotYaml: Map[String, String],
-                         cassandraJvmOptions: String, modified: Boolean, failover: Node.Failover): Node = {
+                         cassandraJvmOptions: String, modified: Boolean, failover: Node.Failover, solrEnabled: Boolean): Node = {
     val node = new Node(id)
     node.state = state
     node.cluster = cluster
@@ -73,6 +73,8 @@ object CassandraStorageTest {
     node.modified = modified
 
     node.failover = failover
+
+    node.solrEnabled = solrEnabled
 
     node
   }
@@ -134,6 +136,8 @@ object CassandraStorageTest {
     assertEquals(expected.failover.delay, actual.failover.delay)
     assertEquals(expected.failover.maxDelay, actual.failover.maxDelay)
     assertEquals(expected.failover.maxTries, actual.failover.maxTries)
+
+    assertEquals(expected.solrEnabled, actual.solrEnabled)
   }
 }
 
@@ -193,7 +197,7 @@ class CassandraStorageTest {
   def testTwoClusters(): Unit = {
     val cluster1 = createCluster("cluster_1", "192.168.*", Map(Node.Port.AGENT -> new Range("5005"), Node.Port.CQL -> null), true, "user", "pass")
     val node1_1 = createNode("1", Node.State.RUNNING, cluster1, createStickiness("30m", "slave0", new Date()), null, 1.5, 2056,
-      true, "", null, null, Map.empty, Map.empty, ".", ".", ".", Map.empty, Map.empty, "", false, new Failover())
+      true, "", null, null, Map.empty, Map.empty, ".", ".", ".", Map.empty, Map.empty, "", false, new Failover(), false)
     Nodes.addCluster(cluster1)
     Nodes.addNode(node1_1)
 
@@ -206,7 +210,7 @@ class CassandraStorageTest {
       createNode("2", Node.State.RECONCILING, cluster2, createStickiness("1h", null, null), runtime, 0.5,
         1024, true, "opt1", "r1", "dc1", Map("hostname" -> List(Constraint("like:master*"))), Map("hostname" -> List(Constraint("like:slave*"))),
         "/tmp/datafile", "/tmp/comitlogdir", "/opt/savedCaches", Map("num_tokens" -> "1"), Map("stomp_interface" -> "10.1.2.3"), "copt1", false,
-        failover)
+        failover, false)
     }
     Nodes.addCluster(cluster2)
     Nodes.addNode(node1_2)
@@ -218,7 +222,7 @@ class CassandraStorageTest {
       createNode("3", Node.State.RECONCILING, cluster2, createStickiness("2h", null, null), runtime, 0.6,
         1024, true, "opt2", "r2", "dc2", Map("hostname" -> List(Constraint("like:slave*"))), Map("hostname" -> List(Constraint("like:master*"))),
         "/tmp/datafile2", "/tmp/comitlogdir2", "/opt/savedCaches2", Map("num_tokens" -> "2"), Map("stomp_interface" -> "10.3.2.1"), "copt2", false,
-        new Failover(new Period("20m"), new Period("10s"), null))
+        new Failover(new Period("20m"), new Period("10s"), null), false)
     }
     Nodes.addNode(node2_2)
 

--- a/src/main/test/net/elodina/mesos/dse/NodeCliTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/NodeCliTest.scala
@@ -127,6 +127,29 @@ class NodeCliTest extends DseMesosTestCase with CliTestCase {
   }
 
   @Test
+  def handleAddUpdate_solr(): Unit = {
+    cli("add 0".split(" "))
+    assertFalse(Nodes.getNode("0").solrEnabled)
+
+    cli("add 1 --solr-enabled true".split(" "))
+
+    val node = Nodes.getNode("1")
+    assertTrue(node.solrEnabled)
+
+    assertTrue(outputToString(NodeCli.printNode(node)).contains("solr: true"))
+
+    cli("update 1 --solr-enabled false".split(" "))
+
+    assertTrue(outputToString(NodeCli.printNode(node)).contains("solr: false"))
+
+    // undefined behaviour
+    cli("add 2 --solr-enabled yo".split(" "))
+    assertFalse(Nodes.getNode("2").solrEnabled)
+    cli("update 2 --solr-enabled ioio".split(" "))
+    assertFalse(Nodes.getNode("2").solrEnabled)
+  }
+
+  @Test
   def handleRemove {
     assertCliError(Array("remove", ""), "node required")
     assertCliError(Array("remove", "+"), "invalid node expr")

--- a/src/main/test/net/elodina/mesos/dse/NodeTest.scala
+++ b/src/main/test/net/elodina/mesos/dse/NodeTest.scala
@@ -25,7 +25,7 @@ class NodeTest extends DseMesosTestCase {
     assertEquals("no suitable jmx port", node.matches(offer("cpus:0.5; mem:500; ports:5..5")))
     assertEquals("no suitable thrift port", node.matches(offer("cpus:0.5; mem:500; ports:5..7")))
 
-    assertNull(node.matches(offer("cpus:0.5; mem:500; ports:0..4")))
+    assertNull(node.matches(offer("cpus:0.5; mem:500; ports:0..6")))
   }
 
   @Test
@@ -56,13 +56,13 @@ class NodeTest extends DseMesosTestCase {
     var reservation = node.reserve(offer("cpus:0.3;mem:300;ports:0..1"))
     assertEquals(0.3d, reservation.cpus, 0.001)
     assertEquals(300, reservation.mem)
-    assertEquals(Map(Port.STORAGE -> 0, Port.JMX -> 1, Port.CQL -> -1, Port.THRIFT -> -1, Port.AGENT -> -1), reservation.ports)
+    assertEquals(Map(Port.STORAGE -> 0, Port.JMX -> 1, Port.CQL -> -1, Port.THRIFT -> -1, Port.AGENT -> -1, Port.SOLR_HTTP -> -1, Port.SOLR_SHARD -> -1), reservation.ports)
 
     // complete reservation
     reservation = node.reserve(offer("cpus:0.7;mem:1000;ports:0..10"))
     assertEquals(node.cpu, reservation.cpus, 0.001)
     assertEquals(node.mem, reservation.mem)
-    assertEquals(Map(Port.STORAGE -> 0, Port.JMX -> 1, Port.CQL -> 2, Port.THRIFT -> 3, Port.AGENT -> 4), reservation.ports)
+    assertEquals(Map(Port.STORAGE -> 0, Port.JMX -> 1, Port.CQL -> 2, Port.THRIFT -> 3, Port.AGENT -> 4, Port.SOLR_HTTP -> 5, Port.SOLR_SHARD -> 6), reservation.ports)
   }
 
   @Test
@@ -168,7 +168,7 @@ class NodeTest extends DseMesosTestCase {
     val read: Node = new Node(Util.parseJsonAsMap(data), expanded = true)
     assertEquals(node, read)
 
-    assertEquals(resources("cpus:0.1; mem:500; ports:0..0; ports:1..1; ports:2..2; ports:3..3; ports:4..4"), task.getResourcesList)
+    assertEquals(resources("cpus:0.1; mem:500; ports:0..0; ports:1..1; ports:2..2; ports:3..3; ports:4..4; ports:5..5; ports:6..6"), task.getResourcesList)
   }
 
   @Test

--- a/vagrant/cassandra_schema.cql
+++ b/vagrant/cassandra_schema.cql
@@ -52,5 +52,6 @@ CREATE TABLE IF NOT EXISTS dse_mesos_framework(
         node_failover_max_tries int,
         node_failover_failures int,
         node_failover_failure_time timestamp,
+        node_solr_enabled boolean,
         PRIMARY KEY(namespace, framework_id, cluster_id, node_id)
 );


### PR DESCRIPTION
MOTIVATION:
Launch SOLR on DSE.

PROPOSED CHANGE:

CLI changes:
- node CLI: add option `--solr-enabled` with possible values: `true` to launch SOLR on the node, otherwise `false`

    ./dse-mesos.sh node add 0 --cpu 0.1 --mem 1536 --solr-enabled true

- node CLI: include into output `solr: <true | false>` of `node list`
- cluster CLI: options for SOLR ports (catalina port, shart transport netty port)

Http server changes:
- handle solrEnabled for add/update HTTP API calls

Scheduler changes:
- reserve SOLR ports

Excecutor changes:
- whenever `solrEnabled` is true include flag `-s` when startting C* node
- configure ports for SOLR:
  - catalina port in catalina.properties
  - shart transport port in dse.yaml

Node changes:
- add serialization to/from JSON of attribute solrEnabled

Storage changes:
- File/Zk  update migraiton to add false value for attribute `solrEnabled`
- C* storage added column node_solr_enabled (default: false)

RESULT: ability to launch DSE search nodes
