### PR TITLE
Fix version discrepancy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'scala'
 apply plugin: 'idea'
 
-version = '0.2.1.2'
+version = '0.2.1.3'
 
 jar.archiveName = "dse-mesos-${version}.jar"
 libsDirName = '../'


### PR DESCRIPTION
Version in build.gradle and Scheduler did not match. This PR bumps build.gradle to 0.2.1.3 (same as in Scheduler.scala)
